### PR TITLE
docs: Refine landing and agent docs

### DIFF
--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,6 +1,12 @@
 # Skillet
 
-Skillet builds agent skills from a reviewable specification and evaluates them through real coding-agent CLIs.
+> Build agent skills from a reviewable spec, run them against real prompts, and improve them over time.
+
+Skillet keeps the spec, agent instructions, and eval cases separate so you can see what changed and improve the right part of the skill.
+
+- [Documentation](/)
+- [GitHub](https://github.com/getsentry/skillet)
+- [npm](https://www.npmjs.com/package/@sentry/skillet)
 
 ## Start Here
 

--- a/docs/scripts/finalize-build.mjs
+++ b/docs/scripts/finalize-build.mjs
@@ -1,4 +1,12 @@
-import { copyFileSync, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, extname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -15,11 +23,23 @@ const walk = (directory) =>
     return entry.isDirectory() ? walk(path) : [path];
   });
 
-const missingRoutes = walk(sourceRoot)
+const sourcePages = walk(sourceRoot)
   .filter((path) => [".md", ".mdx"].includes(extname(path)))
-  .map((path) => relative(sourceRoot, path))
-  .filter((path) => path !== "index.mdx")
-  .map((path) => path.replace(/\.mdx?$/, ".md"))
+  .map((path) => ({ source: path, route: relative(sourceRoot, path) }))
+  .filter(({ route }) => route !== "index.mdx");
+
+for (const { source, route } of sourcePages) {
+  const output = join(distRoot, route.replace(/\.mdx?$/, ".md"));
+  const content = readFileSync(source, "utf8").replace(
+    /(\]\()(\/[^)\s?#]+)\/([?#][^)]*)?(\))/g,
+    (_, open, path, suffix = "", close) => `${open}${path}.md${suffix}${close}`,
+  );
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, content);
+}
+
+const missingRoutes = sourcePages
+  .map(({ route }) => route.replace(/\.mdx?$/, ".md"))
   .filter((path) => !existsSync(join(distRoot, path)));
 
 if (missingRoutes.length > 0) {

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -8,7 +8,7 @@ url: /
 
 Skillet helps you build skills without guessing:
 
-Ask your coding agent to create or improve a skill. The authoring skill drives the CLI workflow while you review the spec and eval results.
+Ask your coding agent to create or improve a skill. The authoring skill uses the Skillet CLI to draft the files and run the checks while you review the spec and eval results.
 
 1. Define the contract in `spec.md`.
 2. Render the contract into agent instructions.

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -8,6 +8,8 @@ url: /
 
 Skillet helps you build skills without guessing:
 
+Ask your coding agent to create or improve a skill. The authoring skill drives the CLI workflow while you review the spec and eval results.
+
 1. Define the contract in `spec.md`.
 2. Render the contract into agent instructions.
 3. Run realistic eval cases through a coding-agent CLI.

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -6,14 +6,14 @@ url: /
 
 # Skillet
 
-Skillet turns intent into a reviewable workflow for agent behavior:
+Skillet helps you build skills without guessing:
 
 1. Define the contract in `spec.md`.
 2. Render the contract into agent instructions.
 3. Run realistic eval cases through a coding-agent CLI.
 4. Diagnose failures and improve the spec, instructions, or eval.
 
-Skillet does not claim that a passing eval makes a skill universally correct. Evals provide repeatable evidence for the scenarios you define and a way to iterate on observed behavior.
+Skillet does not claim that a passing eval makes a skill universally correct. Evals give you repeatable evidence for the scenarios you define and a way to keep improving the skill.
 
 ## Start Here
 

--- a/docs/src/content/docs/concepts/artifact-lifecycle.md
+++ b/docs/src/content/docs/concepts/artifact-lifecycle.md
@@ -49,7 +49,7 @@ skillet status path/to/my-skill
 
 This makes agent and human edits interchangeable. A new session can continue from the repository without reconstructing previous conversation state.
 
-## Improvement Loop
+## Improve a Skill
 
 ```text
 specify → render → evaluate → diagnose → improve

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -15,51 +15,6 @@ hero:
 ---
 
 <div className="skillet-home">
-  <section className="skillet-proof" aria-label="Skillet status output">
-    <div className="skillet-session">
-      <div className="skillet-window-bar">
-        <span></span><span></span><span></span>
-        <strong>terminal</strong>
-      </div>
-      <pre><code>{`$ skillet status ./commit-conventions
-
-Skill: /path/to/commit-conventions
-[x] spec.md
-[x] SKILL.md
-[x] evals/cases/ (2 cases)
-
-Next: Run 'skillet validate' and 'skillet eval';
-diagnose failures from 'skillet eval --json' transcripts.`}</code></pre>
-    </div>
-  </section>
-
-  <section className="skillet-section">
-    <div className="skillet-section-heading">
-      <p className="skillet-kicker">How it works</p>
-      <h2 id="why-skillet">Three files. Clear responsibilities.</h2>
-      <p><code>spec.md</code> defines the behavior. <code>SKILL.md</code> tells the agent what to do. Eval cases show how it behaved in concrete scenarios.</p>
-    </div>
-
-    <div className="skillet-card-grid">
-      <a className="skillet-card" href="/concepts/specifications/">
-        <strong>Write it down</strong>
-        <span>Turn the idea into behaviors and scenarios you can review.</span>
-      </a>
-      <a className="skillet-card" href="/guides/write-agent-instructions/">
-        <strong>Give the agent the playbook</strong>
-        <span>Render the spec into focused instructions the agent can actually follow.</span>
-      </a>
-      <a className="skillet-card" href="/guides/write-honest-evals/">
-        <strong>Run real prompts</strong>
-        <span>Try the skill in clean workspaces and inspect what it leaves behind.</span>
-      </a>
-      <a className="skillet-card" href="/concepts/artifact-lifecycle/">
-        <strong>Fix what missed</strong>
-        <span>Use failures and baseline results to improve the spec, instructions, or eval.</span>
-      </a>
-    </div>
-  </section>
-
   <section className="skillet-section skillet-install-section">
     <div>
       <p className="skillet-kicker">Use your coding agent</p>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,8 +3,8 @@ title: Skillet
 description: Build agent skills from a reviewable specification, evaluate their behavior, and improve them over time.
 template: splash
 hero:
-  title: '<span class="skillet-mega">Skillet</span><span class="skillet-headline">Specify behavior. <span class="skillet-highlight">Evaluate and improve.</span></span>'
-  tagline: 'Turn intent into <code>spec.md</code>, agent instructions, and eval cases—a reviewable loop for iterating on how a skill behaves.'
+  title: '<span class="skillet-mega">Skillet</span><span class="skillet-headline">Build skills <span class="skillet-highlight">without guessing.</span></span>'
+  tagline: 'Write down what the skill should do. Run it against real prompts. Improve the spec, instructions, or eval when it misses.'
   actions:
     - text: Get Started
       link: /quickstart/
@@ -35,33 +35,35 @@ diagnose failures from 'skillet eval --json' transcripts.`}</code></pre>
 
   <section className="skillet-section">
     <div className="skillet-section-heading">
-      <h2 id="why-skillet">A workflow for agent behavior</h2>
-      <p>Skillet separates intent, instructions, and evaluation so you can see what changed, diagnose weak behavior, and improve the right artifact.</p>
+      <p className="skillet-kicker">How it works</p>
+      <h2 id="why-skillet">The loop is the product.</h2>
+      <p>Skillet keeps intent, instructions, and evals separate so you can change the right thing instead of prompt-tweaking in circles.</p>
     </div>
 
     <div className="skillet-card-grid">
       <a className="skillet-card" href="/concepts/specifications/">
-        <strong>Specify</strong>
-        <span>Describe triggers, observable behaviors, scenarios, and constraints in a strict Markdown contract.</span>
+        <strong>Write it down</strong>
+        <span>Turn the idea into behaviors and scenarios you can review.</span>
       </a>
       <a className="skillet-card" href="/guides/write-agent-instructions/">
-        <strong>Render</strong>
-        <span>Turn the contract into concise instructions structured for an agent to execute.</span>
+        <strong>Give the agent the playbook</strong>
+        <span>Render the spec into focused instructions the agent can actually follow.</span>
       </a>
       <a className="skillet-card" href="/guides/write-honest-evals/">
-        <strong>Evaluate</strong>
-        <span>Run realistic cases in fresh workspaces and check the artifacts the agent leaves behind.</span>
+        <strong>Run real prompts</strong>
+        <span>Try the skill in clean workspaces and inspect what it leaves behind.</span>
       </a>
       <a className="skillet-card" href="/concepts/artifact-lifecycle/">
-        <strong>Improve</strong>
-        <span>Use failures and baseline results to decide whether to change the spec, instructions, or eval case.</span>
+        <strong>Fix what missed</strong>
+        <span>Use failures and baseline results to improve the spec, instructions, or eval.</span>
       </a>
     </div>
   </section>
 
   <section className="skillet-section skillet-install-section">
     <div>
-      <h2 id="quick-start">Start with the agent you already use</h2>
+      <p className="skillet-kicker">No new model setup</p>
+      <h2 id="quick-start">Use the agent you already have.</h2>
       <p>Skillet makes no model API calls. It serves artifact instructions and runs evals through Codex, Claude Code, or a custom CLI harness.</p>
     </div>
 
@@ -80,8 +82,9 @@ Ask your agent:
 
   <section className="skillet-section">
     <div className="skillet-section-heading">
-      <h2 id="measured-lift">Use results to choose the next change</h2>
-      <p>Baseline runs compare the same prompt and configured agent without the skill, giving you another signal for where iteration is useful.</p>
+      <p className="skillet-kicker">Baseline and lift</p>
+      <h2 id="measured-lift">See what changed.</h2>
+      <p>Run the same prompts with and without the skill. The numbers do not grade truth—they show where the skill changes behavior.</p>
     </div>
 
     <div className="skillet-results">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -82,14 +82,42 @@ Ask your agent:
 
   <section className="skillet-section">
     <div className="skillet-section-heading">
-      <p className="skillet-kicker">Baseline and lift</p>
-      <h2 id="measured-lift">See what changed.</h2>
-      <p>Run the same prompts with and without the skill. The numbers do not grade truth—they show where the skill changes behavior.</p>
+      <p className="skillet-kicker">Spec → eval</p>
+      <h2 id="spec-to-eval">Write the behavior down. Then run it.</h2>
+      <p>The spec says what should happen. The eval turns one scenario into a repeatable check. When it misses, improve the spec, instructions, or case.</p>
     </div>
 
-    <div className="skillet-results">
-      <div><span>conventional-subject</span><strong>100%</strong><em>baseline 33%</em><b>+67% lift</b></div>
-      <div><span>branch-safety</span><strong>100%</strong><em>baseline 0%</em><b>+100% lift</b></div>
+    <div className="skillet-example-grid">
+      <div className="skillet-example">
+        <div className="skillet-window-bar">
+          <span></span><span></span><span></span>
+          <strong>spec.md</strong>
+        </div>
+        <pre><code>{`### Behavior: Branch safety
+
+The agent SHALL NOT commit directly to \`main\`.
+
+#### Scenario: Commit requested on main
+
+- **WHEN** the user asks to commit on \`main\`
+- **THEN** the agent creates a branch first`}</code></pre>
+      </div>
+
+      <div className="skillet-example">
+        <div className="skillet-window-bar">
+          <span></span><span></span><span></span>
+          <strong>evals/cases/branch-safety.yaml</strong>
+        </div>
+        <pre><code>{`behavior: branch-safety
+prompt: Commit the staged change.
+setup: |
+  git init -q -b main
+  echo change > change.txt
+  git add change.txt
+checks:
+  - shell: test "$(git branch --show-current)" != main
+  - shell: git log -1 --format=%s | grep -q .`}</code></pre>
+      </div>
     </div>
   </section>
 </div>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: Build agent skills from a reviewable specification, evaluate their 
 template: splash
 hero:
   title: '<span class="skillet-mega">Skillet</span><span class="skillet-headline">Build skills <span class="skillet-highlight">without guessing.</span></span>'
-  tagline: 'Write down what the skill should do. Run it against real prompts. Improve the spec, instructions, or eval when it misses.'
+  tagline: 'Describe the skill in plain language. Your agent turns it into a spec, instructions, and eval cases you can review and improve.'
   actions:
     - text: Get Started
       link: /quickstart/
@@ -62,9 +62,9 @@ diagnose failures from 'skillet eval --json' transcripts.`}</code></pre>
 
   <section className="skillet-section skillet-install-section">
     <div>
-      <p className="skillet-kicker">No new model setup</p>
-      <h2 id="quick-start">Use the agent you already have.</h2>
-      <p>Skillet makes no model API calls. It serves artifact instructions and runs evals through Codex, Claude Code, or a custom CLI harness.</p>
+      <p className="skillet-kicker">Agent-driven</p>
+      <h2 id="quick-start">You ask. Your agent runs the loop.</h2>
+      <p>Ask for a skill in plain language. The authoring skill drafts the spec, renders the instructions, writes eval cases, and follows the next step from the files on disk. You review the contract and results.</p>
     </div>
 
     <div className="skillet-terminal">

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -36,8 +36,8 @@ diagnose failures from 'skillet eval --json' transcripts.`}</code></pre>
   <section className="skillet-section">
     <div className="skillet-section-heading">
       <p className="skillet-kicker">How it works</p>
-      <h2 id="why-skillet">The loop is the product.</h2>
-      <p>Skillet keeps intent, instructions, and evals separate so you can change the right thing instead of prompt-tweaking in circles.</p>
+      <h2 id="why-skillet">Three files. Clear responsibilities.</h2>
+      <p><code>spec.md</code> defines the behavior. <code>SKILL.md</code> tells the agent what to do. Eval cases show how it behaved in concrete scenarios.</p>
     </div>
 
     <div className="skillet-card-grid">
@@ -62,9 +62,9 @@ diagnose failures from 'skillet eval --json' transcripts.`}</code></pre>
 
   <section className="skillet-section skillet-install-section">
     <div>
-      <p className="skillet-kicker">Agent-driven</p>
-      <h2 id="quick-start">You ask. Your agent runs the loop.</h2>
-      <p>Ask for a skill in plain language. The authoring skill drafts the spec, renders the instructions, writes eval cases, and follows the next step from the files on disk. You review the contract and results.</p>
+      <p className="skillet-kicker">Use your coding agent</p>
+      <h2 id="quick-start">Ask for a skill in plain language.</h2>
+      <p>The authoring skill drafts the spec, renders the instructions, writes eval cases, and checks what comes next from the files on disk. You review the spec and results.</p>
     </div>
 
     <div className="skillet-terminal">

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -240,14 +240,15 @@ body {
 .skillet-example-grid {
   display: grid;
   gap: 0.8rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
+  max-width: 64rem;
 }
 
 .skillet-example pre {
   background: transparent;
   border: 0;
   margin: 0;
-  min-height: 17rem;
+  min-height: 0;
   overflow-x: auto;
   padding: 1.15rem;
 }

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -162,11 +162,25 @@ body {
   max-width: 48rem;
 }
 
+.skillet-section h2::before {
+  display: none;
+}
+
 .skillet-section h2 {
-  font-size: clamp(2rem, 4vw, 3.15rem);
-  letter-spacing: -0.035em;
+  font-size: clamp(1.9rem, 3vw, 2.7rem);
+  letter-spacing: -0.025em;
   line-height: 1;
   margin-bottom: 0.8rem;
+}
+
+.skillet-kicker {
+  color: #c6a6ff !important;
+  font-family: var(--__sl-font-mono);
+  font-size: 0.72rem !important;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
 }
 
 .skillet-section p {
@@ -194,6 +208,11 @@ body {
   transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
 }
 
+.sl-markdown-content .skillet-card,
+.sl-markdown-content .skillet-card * {
+  text-decoration: none;
+}
+
 .skillet-card:hover {
   background: rgba(255, 255, 255, 0.045);
   border-color: rgba(242, 168, 255, 0.45);
@@ -202,7 +221,7 @@ body {
 
 .skillet-card strong {
   color: #fff;
-  font-size: 1rem;
+  font-size: 1.05rem;
 }
 
 .skillet-card span {

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -82,12 +82,6 @@ body {
   overflow-x: clip;
 }
 
-.skillet-proof {
-  margin: 1rem 0 3rem;
-  max-width: 64rem;
-}
-
-.skillet-session,
 .skillet-terminal,
 .skillet-example {
   background:
@@ -137,7 +131,6 @@ body {
   margin-left: 0.25rem;
 }
 
-.skillet-session pre,
 .skillet-terminal pre {
   background: transparent;
   border: 0;
@@ -145,7 +138,6 @@ body {
   padding: clamp(1.1rem, 3vw, 1.65rem);
 }
 
-.skillet-session code,
 .skillet-terminal code {
   color: rgba(255, 255, 255, 0.82);
   font-size: 0.8rem;
@@ -187,47 +179,6 @@ body {
   color: rgba(255, 255, 255, 0.68);
   font-size: 1.04rem;
   line-height: 1.6;
-}
-
-.skillet-card-grid {
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.skillet-card {
-  background: rgba(255, 255, 255, 0.025);
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 7px;
-  color: inherit;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  padding: 1.15rem;
-  text-decoration: none;
-  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
-}
-
-.sl-markdown-content .skillet-card,
-.sl-markdown-content .skillet-card * {
-  text-decoration: none;
-}
-
-.skillet-card:hover {
-  background: rgba(255, 255, 255, 0.045);
-  border-color: rgba(242, 168, 255, 0.45);
-  transform: translateY(-2px);
-}
-
-.skillet-card strong {
-  color: #fff;
-  font-size: 1.05rem;
-}
-
-.skillet-card span {
-  color: rgba(255, 255, 255, 0.62);
-  font-size: 0.9rem;
-  line-height: 1.5;
 }
 
 .skillet-install-section {
@@ -276,7 +227,6 @@ body {
     width: 100%;
   }
 
-  .skillet-session,
   .skillet-terminal,
   .skillet-example {
     max-width: calc(100vw - 2.5rem);
@@ -304,11 +254,6 @@ body {
     width: 100%;
   }
 
-  .skillet-proof {
-    width: 100%;
-  }
-
-  .skillet-card-grid,
   .skillet-install-section,
   .skillet-example-grid {
     grid-template-columns: 1fr;

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -89,7 +89,7 @@ body {
 
 .skillet-session,
 .skillet-terminal,
-.skillet-results {
+.skillet-example {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
     #0b0b0c;
@@ -237,46 +237,26 @@ body {
   grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
 }
 
-.skillet-results {
-  padding: 0.4rem 1.2rem;
-}
-
-.skillet-results > div {
-  align-items: center;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+.skillet-example-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: minmax(0, 1fr) auto auto auto;
-  padding: 1rem 0;
+  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.skillet-results > div:last-child {
-  border-bottom: 0;
+.skillet-example pre {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  min-height: 17rem;
+  overflow-x: auto;
+  padding: 1.15rem;
 }
 
-.skillet-results span,
-.skillet-results em,
-.skillet-results b,
-.skillet-results strong {
+.skillet-example code {
+  color: rgba(255, 255, 255, 0.78);
   font-family: var(--__sl-font-mono);
-  font-size: 0.79rem;
-}
-
-.skillet-results span {
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.skillet-results strong {
-  color: #fff;
-}
-
-.skillet-results em {
-  color: rgba(255, 255, 255, 0.46);
-  font-style: normal;
-}
-
-.skillet-results b {
-  color: #9ee6a8;
+  font-size: 0.76rem;
+  line-height: 1.65;
 }
 
 @media (max-width: 760px) {
@@ -297,7 +277,7 @@ body {
 
   .skillet-session,
   .skillet-terminal,
-  .skillet-results {
+  .skillet-example {
     max-width: calc(100vw - 2.5rem);
     width: calc(100vw - 2.5rem);
   }
@@ -328,17 +308,12 @@ body {
   }
 
   .skillet-card-grid,
-  .skillet-install-section {
+  .skillet-install-section,
+  .skillet-example-grid {
     grid-template-columns: 1fr;
   }
 
-  .skillet-results > div {
-    align-items: start;
-    grid-template-columns: 1fr auto;
-  }
-
-  .skillet-results em,
-  .skillet-results b {
-    grid-column: span 1;
+  .skillet-example pre {
+    min-height: 0;
   }
 }


### PR DESCRIPTION
Rewrites the landing page in a simpler Junior-inspired voice: the hero now leads with “Build skills without guessing,” the workflow cards use plain language, and the custom section styling no longer inherits oversized brush accents or link underlines.

The landing now shows a short `spec.md` behavior beside its matching YAML eval case instead of presenting lift percentages as the product pitch. This keeps the focus on the spec → eval → iterate workflow rather than implying Skillet is a quality score.

The agent-facing docs are cleaner too. `llms.txt` follows the standard title/summary/details shape, and the build writes Markdown routes from the documentation sources so code blocks and headings stay intact instead of inheriting the shared exporter’s noisy HTML conversion. Existing route and link validation still runs after generation.

The Vercel project remains protected and domain-neutral. This intentionally does not set Astro's canonical `site` value or enable indexing; those should change when the final public domain is chosen.
