### PR TITLE
docs: Add dogfood examples and tighten guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ checks:
   - judge: The commit message accurately describes the null-check fix.
 ```
 
-Checks inspect the resulting workspace, not just the agent's response. Use `file_exists` and `shell` for deterministic checks; use `judge` when the requirement needs semantic evaluation. See [`examples/commit-conventions`](examples/commit-conventions/) for a complete skill.
+Checks inspect the resulting workspace, not just the agent's response. Use `file_exists` and `shell` for deterministic checks; use `judge` when the requirement needs semantic evaluation. See [`examples/`](examples/) for a small skill plus full Garfield and Effect conversions with preserved upstream snapshots.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ npx -y @sentry/dotagents --user add getsentry/skillet skillet-authoring
 
 `add` records and installs the skill immediately. Run `npx -y @sentry/dotagents --user install` later to refresh it.
 
+Or ask your agent to install the [`skillet-authoring` skill](https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring) for you.
+
 ## Create a skill
 
 Ask your agent:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -24,18 +24,18 @@ export default defineConfig({
           ],
         },
         {
-          label: "Concepts",
+          label: "Build a Skill",
           items: [
-            { label: "Artifact Lifecycle", link: "/concepts/artifact-lifecycle/" },
             { label: "Specifications", link: "/concepts/specifications/" },
-            { label: "Evaluations and Lift", link: "/concepts/evaluations-and-lift/" },
+            { label: "Write Agent Instructions", link: "/guides/write-agent-instructions/" },
+            { label: "Write Honest Evals", link: "/guides/write-honest-evals/" },
+            { label: "Understand Eval Results", link: "/concepts/evaluations-and-lift/" },
           ],
         },
         {
-          label: "Guides",
+          label: "How Skillet Works",
           items: [
-            { label: "Write Agent Instructions", link: "/guides/write-agent-instructions/" },
-            { label: "Write Honest Evals", link: "/guides/write-honest-evals/" },
+            { label: "Artifact Lifecycle", link: "/concepts/artifact-lifecycle/" },
             { label: "Configure Harnesses", link: "/guides/configure-harnesses/" },
             { label: "Sandbox and CI", link: "/guides/sandbox-and-ci/" },
           ],

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
             { label: "Overview", link: "/" },
             { label: "Quickstart", link: "/quickstart/" },
             { label: "Create Your First Skill", link: "/first-skill/" },
+            { label: "Examples", link: "/examples/" },
           ],
         },
         {

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,16 +14,16 @@ Skillet keeps the spec, agent instructions, and eval cases separate so you can s
 - [Quickstart](/quickstart.md)
 - [Create Your First Skill](/first-skill.md)
 
-## Concepts
+## Build a Skill
 
-- [Artifact Lifecycle](/concepts/artifact-lifecycle.md)
 - [Specifications](/concepts/specifications.md)
-- [Evaluations and Lift](/concepts/evaluations-and-lift.md)
-
-## Guides
-
 - [Write Agent Instructions](/guides/write-agent-instructions.md)
 - [Write Honest Evals](/guides/write-honest-evals.md)
+- [Understand Eval Results](/concepts/evaluations-and-lift.md)
+
+## How Skillet Works
+
+- [Artifact Lifecycle](/concepts/artifact-lifecycle.md)
 - [Configure Harnesses](/guides/configure-harnesses.md)
 - [Sandbox and CI](/guides/sandbox-and-ci.md)
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -13,6 +13,7 @@ Skillet keeps the spec, agent instructions, and eval cases separate so you can s
 - [Overview](/index.md)
 - [Quickstart](/quickstart.md)
 - [Create Your First Skill](/first-skill.md)
+- [Examples](/examples.md)
 
 ## Build a Skill
 

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -21,6 +21,7 @@ Skillet does not claim that a passing eval makes a skill universally correct. Ev
 
 - [Quickstart](/quickstart.md)
 - [Create Your First Skill](/first-skill.md)
+- [Examples](/examples.md)
 
 ## Build a Skill
 

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -22,16 +22,16 @@ Skillet does not claim that a passing eval makes a skill universally correct. Ev
 - [Quickstart](/quickstart.md)
 - [Create Your First Skill](/first-skill.md)
 
-## Concepts
+## Build a Skill
 
-- [Artifact Lifecycle](/concepts/artifact-lifecycle.md)
 - [Specifications](/concepts/specifications.md)
-- [Evaluations and Lift](/concepts/evaluations-and-lift.md)
-
-## Guides
-
 - [Write Agent Instructions](/guides/write-agent-instructions.md)
 - [Write Honest Evals](/guides/write-honest-evals.md)
+- [Understand Eval Results](/concepts/evaluations-and-lift.md)
+
+## How Skillet Works
+
+- [Artifact Lifecycle](/concepts/artifact-lifecycle.md)
 - [Configure Harnesses](/guides/configure-harnesses.md)
 - [Sandbox and CI](/guides/sandbox-and-ci.md)
 

--- a/docs/src/content/docs/concepts/artifact-lifecycle.md
+++ b/docs/src/content/docs/concepts/artifact-lifecycle.md
@@ -2,7 +2,7 @@
 title: Artifact Lifecycle
 description: Understand how a Skillet skill moves from intent to measured behavior.
 type: conceptual
-summary: The specification is the contract; instructions and evals are derived artifacts.
+summary: The specification defines behavior; the skill instructions and eval cases are written from it.
 ---
 
 A Skillet skill is a directory of reviewable files. No Skillet command asks a model to generate those files internally.
@@ -17,19 +17,21 @@ my-skill/
     fixtures/
 ```
 
-## The Contract
+## `spec.md`
 
 `spec.md` defines why the skill exists, when it applies, what observable behavior it requires, and what damage it must avoid.
 
-Write and validate the spec before creating derived artifacts. When intent changes, review the spec diff first.
+Write and validate the spec before creating the other files. When intent changes, review the spec diff first. See [Specifications](/concepts/specifications/).
 
-## The Instructions
+## `SKILL.md`
 
-`SKILL.md` is the text the agent loads. It translates the normative contract into an executable workflow.
+`SKILL.md` contains the instructions the agent follows. It turns the requirements in `spec.md` into concrete steps and decisions.
 
 Its frontmatter records a hash of `spec.md`. `skillet status` uses that hash to detect when the instructions are stale.
 
-## The Evidence
+See [Write Agent Instructions](/guides/write-agent-instructions/).
+
+## Eval Cases
 
 Each file under `evals/cases/` links to a behavior or constraint by its stable slug. Cases run through a configured agent harness in fresh workspaces.
 
@@ -38,6 +40,8 @@ Checks inspect the workspace after the agent finishes:
 - `file_exists` verifies an exact path.
 - `shell` runs direct deterministic assertions.
 - `judge` grades semantic requirements through the same agent harness.
+
+See [Write Honest Evals](/guides/write-honest-evals/).
 
 ## Filesystem State Drives the Workflow
 

--- a/docs/src/content/docs/concepts/evaluations-and-lift.md
+++ b/docs/src/content/docs/concepts/evaluations-and-lift.md
@@ -1,11 +1,11 @@
 ---
-title: Evaluations and Lift
-description: Measure whether a skill changes agent behavior rather than merely passing a demonstration.
+title: Understand Eval Results
+description: Compare case results with and without a skill.
 type: conceptual
-summary: Cases run with and without the skill so the result includes baseline pass rate and lift.
+summary: Baseline runs use the same cases without the skill. Lift is the difference between the two pass rates.
 ---
 
-Skillet evals run realistic prompts through a coding-agent CLI in fresh workspaces. The result is graded from the workspace state, not from whether the response sounded convincing.
+Skillet evals run prompts through a coding-agent CLI in fresh workspaces. Results apply only to the prompts, checks, harness, configuration, and trials in that run. Use them to compare tested outcomes and decide what to inspect next, not to grade the overall quality or accuracy of a skill.
 
 ## Trials
 
@@ -19,7 +19,7 @@ Skillet reports pass rates per case and per behavior.
 
 ## Baseline
 
-A passing skill case alone does not show that the skill helped. The configured agent may already behave that way.
+A passing case shows that the agent met the case with the skill installed. Run a baseline to see whether the result changes without the skill.
 
 ```bash
 skillet eval --trials 3 --baseline
@@ -35,9 +35,14 @@ Behaviors:
 
 Lift is the difference between the skill pass rate and the baseline pass rate.
 
-## Interpret Zero Lift
+## Zero Lift
 
-Zero lift is not automatically a failed skill. It means the configured agent already passed the case without it. Decide whether the skill still provides value through consistency, portability, or explicit policy.
+Zero lift means the skill and baseline had the same pass rate in these runs.
+
+- A high pass rate for both means the configured agent already met the tested cases.
+- A low pass rate for both means the skill did not change those results.
+
+Review the case results, transcripts, and checks before deciding what to change.
 
 ## Dry Runs
 
@@ -45,7 +50,7 @@ Zero lift is not automatically a failed skill. It means the configured agent alr
 skillet eval --dry
 ```
 
-A dry run does not spawn an agent. It runs deterministic checks against the untouched fixture and setup workspace. Any passing check is potentially vacuous.
+A dry run applies deterministic checks before an agent changes the workspace. If a check already passes, it may not test the agent's work.
 
 Dry runs cannot assess judge checks and do not replace baseline measurement.
 
@@ -54,4 +59,4 @@ Dry runs cannot assess judge checks and do not replace baseline measurement.
 - **Fail:** the agent completed, but one or more checks did not pass.
 - **Error:** setup, process execution, timeout, or judge protocol failed.
 
-Keep those outcomes separate. A harness authentication failure says nothing about skill quality.
+Keep those outcomes separate. Treat a harness authentication failure as an infrastructure error, not a case result.

--- a/docs/src/content/docs/concepts/specifications.md
+++ b/docs/src/content/docs/concepts/specifications.md
@@ -27,14 +27,14 @@ Use one or two paragraphs to explain what the skill changes and why it exists. K
 
 ## Triggers
 
-Define both sides of the activation boundary:
+State when the skill should and should not load:
 
 ```markdown
 - **SHOULD** apply when the user asks to commit changes
 - **SHOULD NOT** apply when the user only asks to review changes
 ```
 
-The negative boundary prevents a broadly worded skill from loading for nearby tasks it should not control.
+The `SHOULD NOT` rule keeps the skill out of related tasks it does not cover.
 
 ## Behaviors
 
@@ -51,7 +51,7 @@ The agent SHALL NOT commit directly to `main`.
 - **THEN** the agent creates a descriptive branch before committing
 ```
 
-Behavior names slugify into stable identifiers such as `branch-safety`. Eval cases use those identifiers for coverage.
+Skillet converts behavior names into stable IDs such as `branch-safety`. Eval cases use these IDs to link back to the spec.
 
 Every behavior needs at least one scenario. If a statement cannot produce a concrete WHEN/THEN example, it is probably context rather than a behavior.
 

--- a/docs/src/content/docs/examples.md
+++ b/docs/src/content/docs/examples.md
@@ -1,45 +1,161 @@
 ---
 title: Examples
-description: Explore complete Skillet skills from a small starter to full upstream conversions.
+description: See how Skillet turns small and large source skills into reviewable specs, focused instructions, and eval cases.
 type: tutorial
-summary: Compare source skills with their Skillet specs, rendered instructions, references, fixtures, and eval cases.
+summary: Compare original skills with their Skillet specs, rendered instructions, fixtures, references, and eval cases.
 ---
 
-The repository includes three runnable examples under [`examples/`](https://github.com/getsentry/skillet/tree/main/examples).
+Three examples show the same artifact flow at different sizes:
+
+| Example | Starting Point | Behaviors | Best For |
+| --- | --- | ---: | --- |
+| [Commit Conventions](#commit-conventions) | Written from scratch | 2 | Learning the file layout |
+| [Garfield](#garfield) | Existing coordination skill | 6 | Subagents, policies, and review behavior |
+| [Effect](#effect) | Existing technical reference skill | 8 | Large reference libraries and semantic evals |
+
+The Garfield and Effect directories preserve their exact upstream source under `original/`. The runnable Skillet version lives beside it at the example root.
 
 ## Commit Conventions
 
-[`examples/commit-conventions`](https://github.com/getsentry/skillet/tree/main/examples/commit-conventions) is the smallest example. It contains:
+The [Commit Conventions example](https://github.com/getsentry/skillet/tree/main/examples/commit-conventions) is small enough to read in one sitting.
 
-- a two-behavior `spec.md`
-- a compact `SKILL.md`
-- deterministic and semantic eval checks
+The spec names the behavior and gives it a concrete scenario:
 
-Start here when you want to see the artifact layout without a large reference library.
+```markdown title="spec.md"
+### Behavior: Branch safety
+
+The agent MUST NOT commit directly to the main branch.
+
+#### Scenario: Asked to commit while on main
+
+- **WHEN** the working copy is on `main` with a staged change
+- **THEN** the commit lands on a new non-main branch
+```
+
+The eval turns that scenario into a workspace and direct checks:
+
+```yaml title="evals/cases/branch-safety.yaml"
+behavior: branch-safety
+prompt: |
+  Commit the staged change.
+setup: |
+  git init -q -b main
+  git add -A
+checks:
+  - shell: test "$(git branch --show-current)" != main
+  - shell: test "$(git rev-list --count main)" -eq 1
+```
+
+Use this example to learn the relationship between `spec.md`, `SKILL.md`, and `evals/cases/` before opening a larger skill.
+
+---
 
 ## Garfield
 
-[`examples/garfield`](https://github.com/getsentry/skillet/tree/main/examples/garfield) converts the Garfield implementation-review skill from `dcramer/agents`.
+[Garfield](https://github.com/getsentry/skillet/tree/main/examples/garfield) starts from a large implementation-review skill in [`dcramer/agents`](https://github.com/dcramer/agents/tree/main/skills/garfield).
 
-The example keeps two views:
+The upstream skill contains a detailed coordination contract:
 
-- [`original/`](https://github.com/getsentry/skillet/tree/main/examples/garfield/original) preserves the exact pinned upstream snapshot and license.
-- The example root contains the Skillet-authored behavior spec, compact skill instructions, copied policy references, review fixture, and six eval cases.
+```markdown title="original/SKILL.md"
+- Snapshot the core user or PR intent before review.
+- Use one no-edit subagent per applicable review task.
+- Keep at most 3 Garfield subagents open at once.
+- Accept only findings caused by the current diff.
+- Fix only what preserves the captured intent.
+```
 
-Use this example to see how Skillet handles a coordination-heavy skill whose important behavior appears in subagent selection, finding triage, validation, and final handoff.
+The Skillet spec turns those instructions into observable behaviors. For example:
+
+```markdown title="spec.md"
+### Behavior: Delegate in Bounded Batches
+
+The agent SHALL use one no-edit subagent for each applicable review task or
+policy, keep at most three Garfield subagents open at once, and drain completed
+reviewers before starting more.
+
+#### Scenario: Five Applicable Reviews
+
+- **WHEN** five review tasks apply to a code slice
+- **THEN** the agent starts no more than three reviewers, collects completed
+  reviewers, then starts the remaining reviews
+```
+
+The matching eval checks a real implementation slice and uses one judge for the coordination behavior that cannot be read from files alone:
+
+```yaml title="evals/cases/delegate-in-bounded-batches.yaml"
+behavior: delegate-in-bounded-batches
+fixture: review-slice
+prompt: |
+  Use Garfield to review and finish this implementation slice.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.js
+  - judge: >
+      The agent used no-edit subagents, kept at most three Garfield reviewers
+      open at once, and drained review agents before verification.
+```
+
+Explore both versions:
+
+- [Generated Garfield skill](https://github.com/getsentry/skillet/tree/main/examples/garfield)
+- [Pinned original snapshot](https://github.com/getsentry/skillet/tree/main/examples/garfield/original)
+- [Upstream provenance and license](https://github.com/getsentry/skillet/blob/main/examples/garfield/UPSTREAM.md)
+
+---
 
 ## Effect
 
-[`examples/effect`](https://github.com/getsentry/skillet/tree/main/examples/effect) converts the Effect TypeScript guidance skill from `kitlangton/skills`.
+[Effect](https://github.com/getsentry/skillet/tree/main/examples/effect) starts from the reference-heavy TypeScript skill in [`kitlangton/skills`](https://github.com/kitlangton/skills/tree/main/skills/effect).
 
-The example also keeps two views:
+The upstream skill carries a large API selection guide:
 
-- [`original/`](https://github.com/getsentry/skillet/tree/main/examples/effect/original) preserves the exact pinned upstream snapshot and license.
-- The example root contains the Skillet-authored behavior spec, compact reference-driven skill, Effect application fixture, and eight semantic eval cases.
+```markdown title="original/SKILL.md"
+- Unknown boundary payload: `Schema.decodeUnknownEffect(...)`.
+- Service boundary: `Context.Service(...)` plus `Layer.effect(...)`.
+- Retry transient operation: `Effect.retry(...)` with a bounded `Schedule`.
+- Time-sensitive test: `TestClock`, not real sleeping.
+```
 
-Use this example to see how a large technical guide can keep detailed reference material while the main skill stays short and task-oriented.
+The Skillet spec keeps the main contract behavioral and moves API detail into references:
 
-## Validate the Examples
+```markdown title="spec.md"
+### Behavior: Keep External Boundaries Truthful
+
+The agent SHALL decode untrusted responses, preserve typed transport, status,
+and decode failures, and add retries or fallbacks only when the operation and
+recovery policy justify them.
+
+#### Scenario: Retry an Idempotent Provider Request
+
+- **WHEN** an idempotent GET can return rate limits or malformed JSON
+- **THEN** the agent retries only bounded transient failures and keeps exhausted
+  failures visible
+```
+
+The eval uses a flawed provider fixture, a direct file-change gate, and one semantic judge instead of a pile of API-name searches:
+
+```yaml title="evals/cases/keep-external-boundaries-truthful.yaml"
+behavior: keep-external-boundaries-truthful
+fixture: effect-app
+prompt: |
+  Harden src/provider.ts. Decode unknown responses, classify typed failures,
+  and retry only bounded transient failures for this idempotent GET.
+checks:
+  - shell: '! git diff --quiet -- src/provider.ts'
+  - judge: >
+      The implementation separates transport, status, decode, and domain
+      failures; validates unknown data; and keeps exhausted failures visible.
+```
+
+Explore both versions:
+
+- [Generated Effect skill](https://github.com/getsentry/skillet/tree/main/examples/effect)
+- [Pinned original snapshot](https://github.com/getsentry/skillet/tree/main/examples/effect/original)
+- [Upstream provenance and license](https://github.com/getsentry/skillet/blob/main/examples/effect/UPSTREAM.md)
+
+---
+
+## Run the Examples
 
 From a Skillet repository checkout:
 
@@ -53,4 +169,4 @@ skillet eval examples/garfield --dry
 skillet eval examples/effect --dry
 ```
 
-The dry runs check that each case requires agent work without starting model-backed trials.
+The dry runs confirm that every case requires agent work without starting model-backed trials.

--- a/docs/src/content/docs/examples.md
+++ b/docs/src/content/docs/examples.md
@@ -1,0 +1,56 @@
+---
+title: Examples
+description: Explore complete Skillet skills from a small starter to full upstream conversions.
+type: tutorial
+summary: Compare source skills with their Skillet specs, rendered instructions, references, fixtures, and eval cases.
+---
+
+The repository includes three runnable examples under [`examples/`](https://github.com/getsentry/skillet/tree/main/examples).
+
+## Commit Conventions
+
+[`examples/commit-conventions`](https://github.com/getsentry/skillet/tree/main/examples/commit-conventions) is the smallest example. It contains:
+
+- a two-behavior `spec.md`
+- a compact `SKILL.md`
+- deterministic and semantic eval checks
+
+Start here when you want to see the artifact layout without a large reference library.
+
+## Garfield
+
+[`examples/garfield`](https://github.com/getsentry/skillet/tree/main/examples/garfield) converts the Garfield implementation-review skill from `dcramer/agents`.
+
+The example keeps two views:
+
+- [`original/`](https://github.com/getsentry/skillet/tree/main/examples/garfield/original) preserves the exact pinned upstream snapshot and license.
+- The example root contains the Skillet-authored behavior spec, compact skill instructions, copied policy references, review fixture, and six eval cases.
+
+Use this example to see how Skillet handles a coordination-heavy skill whose important behavior appears in subagent selection, finding triage, validation, and final handoff.
+
+## Effect
+
+[`examples/effect`](https://github.com/getsentry/skillet/tree/main/examples/effect) converts the Effect TypeScript guidance skill from `kitlangton/skills`.
+
+The example also keeps two views:
+
+- [`original/`](https://github.com/getsentry/skillet/tree/main/examples/effect/original) preserves the exact pinned upstream snapshot and license.
+- The example root contains the Skillet-authored behavior spec, compact reference-driven skill, Effect application fixture, and eight semantic eval cases.
+
+Use this example to see how a large technical guide can keep detailed reference material while the main skill stays short and task-oriented.
+
+## Validate the Examples
+
+From a Skillet repository checkout:
+
+```bash
+skillet validate examples/commit-conventions
+skillet validate examples/garfield
+skillet validate examples/effect
+
+skillet eval examples/commit-conventions --dry
+skillet eval examples/garfield --dry
+skillet eval examples/effect --dry
+```
+
+The dry runs check that each case requires agent work without starting model-backed trials.

--- a/docs/src/content/docs/first-skill.md
+++ b/docs/src/content/docs/first-skill.md
@@ -2,7 +2,7 @@
 title: Create Your First Skill
 description: Build a small commit-conventions skill from specification through evaluation.
 type: tutorial
-summary: Follow the complete artifact workflow without relying on hidden generation.
+summary: Build a complete skill while your agent writes the artifacts and Skillet validates them.
 ---
 
 This tutorial builds a skill that writes conventional commit subjects and avoids committing directly to `main`.
@@ -69,13 +69,43 @@ skillet validate
 
 ## Render the Agent Instructions
 
-Ask your agent to continue the skill, or fetch the current writing contract yourself:
+Ask your agent:
+
+> Continue this skill from `spec.md`. Write `SKILL.md`, then validate it before adding eval cases.
+
+To write the file yourself, fetch the current format and rules:
 
 ```bash
 skillet instructions skill --json
 ```
 
-Write `SKILL.md` in imperative language. Lead with the workflow the agent must follow, include the important constraints, and keep detailed reference material outside the main skill body.
+Run `skillet status --json` and copy `.spec.hash` into the frontmatter:
+
+```markdown
+---
+name: commit-conventions
+description: Creates safe conventional commits. Use when the user asks to commit changes or write a commit message.
+spec_hash: <copy .spec.hash from skillet status --json>
+---
+
+# Commit Conventions
+
+When the user asks to commit changes:
+
+1. Inspect the current branch and staged diff.
+2. Create a descriptive branch before committing when the repository is on `main`.
+3. Choose the commit type from the staged change.
+4. Commit only related staged changes.
+
+## Commit Subjects
+
+Write `<type>[(scope)]: <description>` with an imperative description. Keep the subject at or under 70 characters and omit the trailing period.
+
+## Never
+
+- Never amend, rebase, or force-push unless the user explicitly asks.
+- Never include unrelated changes in the commit.
+```
 
 Run `skillet status` after writing. The recorded `spec_hash` tells Skillet whether `SKILL.md` is current with the spec.
 
@@ -89,15 +119,43 @@ prompt: |
   Commit the staged null-check fix.
 setup: |
   git init -q -b feature/null-check
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
   printf 'export const value = input ?? "fallback";\n' > value.ts
   git add value.ts
 checks:
-  - shell: git log -1 --format=%s | grep -Eq '^fix(\(.+\))?: .+'
+  - shell: >-
+      git log -1 --format=%s | grep -Eq '^fix(\(.+\))?: .+[^.]$'
+  - shell: >-
+      test "$(git log -1 --format=%s | awk '{ print length }')" -le 70
+  - judge: The commit subject uses imperative language and accurately describes the staged null-check fix.
 ```
 
-The shell check directly verifies the required commit subject. It does not guess which internal commands or reasoning the agent used.
+The shell checks verify the format and length. The judge checks the parts that require meaning: imperative language and an accurate description of the change.
 
-Add a separate case for `branch-safety` so every behavior has coverage.
+Create `evals/cases/branch-safety.yaml` for the second behavior:
+
+```yaml
+behavior: branch-safety
+prompt: |
+  Commit the staged change.
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  printf 'export const base = 0;\n' > base.ts
+  git add base.ts
+  git commit -qm seed
+  printf 'export const value = 1;\n' > value.ts
+  git add value.ts
+checks:
+  - shell: >-
+      test "$(git rev-parse main)" = "$(git rev-list --max-parents=0 HEAD)"
+  - shell: test "$(git branch --show-current)" != main
+  - shell: test "$(git rev-parse HEAD)" != "$(git rev-parse main)"
+```
+
+The first check verifies that `main` still points to the seed commit. The other checks verify that the agent switched branches and created a new commit there.
 
 ## Evaluate the Skill
 

--- a/docs/src/content/docs/guides/sandbox-and-ci.md
+++ b/docs/src/content/docs/guides/sandbox-and-ci.md
@@ -11,7 +11,7 @@ Use direct execution only for skills and eval cases you trust.
 
 ## Build the Sandbox Image
 
-The repository includes a Docker image recipe:
+The Skillet repository includes a Docker image recipe. Clone the repository and run this command from its root:
 
 ```bash
 docker build -t skillet-eval sandbox/
@@ -23,7 +23,7 @@ Run an eval in the container:
 skillet eval --sandbox docker
 ```
 
-Agent and judge invocations run inside Docker with the trial workspace mounted at `/workspace`. Deterministic checks still inspect the mounted workspace from the host.
+Only agent and judge invocations run inside Docker. Case `setup` scripts and `shell` checks still run on the host against the mounted workspace. Treat eval case YAML as trusted input; Docker does not isolate malicious setup or check commands.
 
 ## Configure Sandbox Defaults
 
@@ -69,4 +69,4 @@ Open it locally with:
 npx vitest-evals serve results.json
 ```
 
-Do not run untrusted skill evals directly on a shared CI runner.
+Do not run eval cases you do not trust on a shared CI runner. Docker contains the agent process, not the case's setup and shell commands.

--- a/docs/src/content/docs/guides/write-agent-instructions.md
+++ b/docs/src/content/docs/guides/write-agent-instructions.md
@@ -1,13 +1,13 @@
 ---
 title: Write Agent Instructions
-description: Render a specification into concise instructions an agent can execute.
+description: Turn a specification into clear instructions for an agent.
 type: tutorial
-summary: Translate the contract into workflow, decision points, constraints, and domain-appropriate examples.
+summary: Write concrete steps, decisions, constraints, and examples from the spec.
 ---
 
 `SKILL.md` is not a copy of `spec.md`. The spec uses normative language for validation; the skill uses direct instructions for execution.
 
-Fetch the current rendering contract before writing:
+Fetch the current format and writing rules before writing:
 
 ```bash
 skillet instructions skill --json
@@ -79,4 +79,4 @@ skillet validate
 skillet eval --trials 3 --baseline
 ```
 
-Frontmatter validation catches structural errors. Evals determine whether the instructions actually change behavior.
+Frontmatter validation catches structural errors. Evals show how the agent behaved in the tested cases; baselines compare those results with and without the skill.

--- a/docs/src/content/docs/guides/write-honest-evals.md
+++ b/docs/src/content/docs/guides/write-honest-evals.md
@@ -2,10 +2,10 @@
 title: Write Honest Evals
 description: Test observable outcomes without overfitting to one likely implementation.
 type: tutorial
-summary: Use direct deterministic proof when available and semantic judges when behavior cannot be reduced to exact state.
+summary: Use checks that directly verify an outcome, and judges for semantic requirements.
 ---
 
-An eval case should distinguish behavior that meets the scenario from behavior that only sounds plausible.
+Use checks that directly verify the required result. Use a judge when the requirement depends on meaning, design, or relationships between files.
 
 Fetch the current case-writing contract before authoring:
 
@@ -22,15 +22,15 @@ Map the specification directly:
 
 Use a realistic user request. Do not quote the skill or tell the agent the expected implementation.
 
-## Prefer Direct Deterministic Proof
+## Use Direct Checks When Possible
 
-Strong deterministic checks execute or inspect the required outcome:
+Run or inspect the required result:
 
 ```yaml
 checks:
   - shell: npm test
   - shell: npm run typecheck
-  - shell: git branch --show-current | grep -qv '^main$'
+  - shell: "git log -1 --format=%s | grep -Eq '^fix:'"
   - file_exists: src/generated/client.ts
 ```
 
@@ -82,4 +82,4 @@ skillet eval --dry
 skillet eval --trials 3 --baseline
 ```
 
-`--dry` catches vacuous deterministic checks. `--baseline` shows whether the case separates the skilled and unskilled agent.
+`--dry` finds checks that pass before the agent runs. `--baseline` compares the same configured agent with and without this skill.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -67,11 +67,18 @@ The agent SHALL NOT commit directly to \`main\`.
 prompt: Commit the staged change.
 setup: |
   git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  echo base > base.txt
+  git add base.txt
+  git commit -qm seed
   echo change > change.txt
   git add change.txt
 checks:
+  - shell: >-
+      test "$(git rev-parse main)" = "$(git rev-list --max-parents=0 HEAD)"
   - shell: test "$(git branch --show-current)" != main
-  - shell: git log -1 --format=%s | grep -q .`}</code></pre>
+  - shell: test "$(git rev-parse HEAD)" != "$(git rev-parse main)"`}</code></pre>
       </div>
     </div>
   </section>

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -65,6 +65,8 @@ The authoring skill will:
 5. Add eval cases.
 6. Run validation and evals.
 
+Full evals and baselines start authenticated agent CLI sessions. They can take time and consume model usage.
+
 ## Check the Result
 
 From the new skill directory:
@@ -76,9 +78,11 @@ skillet eval --dry
 skillet eval --trials 3 --baseline
 ```
 
-`status` reports the next artifact, `validate` checks the complete contract, `eval --dry` finds vacuous cases, and `--baseline` measures the difference the skill makes.
+`status` reports the next step, `validate` checks the complete contract, `eval --dry` finds checks that pass before the agent runs, and `--baseline` compares pass rates with and without the skill.
 
 ## Next
 
-- Follow [Create Your First Skill](/first-skill/) for the manual artifact flow.
-- Read [Evaluations and Lift](/concepts/evaluations-and-lift/) before interpreting results.
+1. Follow [Create Your First Skill](/first-skill/) for the complete artifact flow.
+2. Read [Specifications](/concepts/specifications/) before changing skill behavior.
+3. Read [Write Agent Instructions](/guides/write-agent-instructions/) and [Write Honest Evals](/guides/write-honest-evals/) before editing derived files.
+4. Read [Understand Eval Results](/concepts/evaluations-and-lift/) before interpreting trials, baselines, or lift.

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -46,9 +46,11 @@ Run `install` later to refresh declared skills:
 npx -y @sentry/dotagents --user install
 ```
 
-### Install the Skill Directly
+### Ask Your Agent to Install It
 
-If your agent reads skills from another location, copy the [`skills/skillet-authoring`](https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring) directory into that agent's skill directory.
+Or tell your agent:
+
+> Install the [`skillet-authoring` skill](https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring) for me.
 
 ## Ask for a Skill
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -78,7 +78,7 @@ sandbox:
   image: skillet-eval
   mount_auth:
     - ~/.codex
-  network: false
+  network: true
 ```
 
 Invalid YAML or incorrectly typed fields stop the eval before any case runs.

--- a/docs/src/content/docs/reference/eval-case.md
+++ b/docs/src/content/docs/reference/eval-case.md
@@ -8,16 +8,23 @@ summary: Each case links to one spec behavior or constraint and contains a reali
 Store one case per file under `evals/cases/`.
 
 ```yaml
-behavior: conventional-subject
+behavior: branch-safety
 prompt: |
-  Commit the staged null-check fix.
-fixture: git-repo
+  Commit the staged change.
 setup: |
-  git init -q
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  printf 'export const base = 0;\n' > base.ts
+  git add base.ts
+  git commit -qm seed
+  printf 'export const value = 1;\n' > value.ts
+  git add value.ts
 checks:
-  - file_exists: CHANGELOG.md
-  - shell: git log -1 --format=%s | grep -Eq '^fix:'
-  - judge: The commit subject accurately describes the staged change.
+  - shell: >-
+      test "$(git rev-parse main)" = "$(git rev-list --max-parents=0 HEAD)"
+  - shell: test "$(git branch --show-current)" != main
+  - shell: test "$(git rev-parse HEAD)" != "$(git rev-parse main)"
 trials: 3
 timeout: 300
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,21 @@
+# Examples
+
+| Example | What It Shows | Upstream Snapshot |
+| --- | --- | --- |
+| [`commit-conventions/`](commit-conventions/) | A small skill authored directly with Skillet | None |
+| [`garfield/`](garfield/) | A large coordination skill converted into a compact spec, references, and eval suite | `dcramer/agents` |
+| [`effect/`](effect/) | A reference-heavy technical skill converted into behavior-focused artifacts and semantic evals | `kitlangton/skills` |
+
+The Garfield and Effect examples keep their exact source snapshots under `original/`. Their runnable Skillet artifacts live at the example root.
+
+Validate every example:
+
+```bash
+skillet validate examples/commit-conventions
+skillet validate examples/garfield
+skillet validate examples/effect
+
+skillet eval examples/commit-conventions --dry
+skillet eval examples/garfield --dry
+skillet eval examples/effect --dry
+```

--- a/examples/effect/LICENSE
+++ b/examples/effect/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kit Langton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/effect/README.md
+++ b/examples/effect/README.md
@@ -1,0 +1,13 @@
+# Effect Example
+
+This directory contains two versions of the Effect skill:
+
+- `original/` is an exact snapshot of `kitlangton/skills/skills/effect` at the commit recorded in `UPSTREAM.md`.
+- The files at this directory root are a Skillet-authored version with a behavior spec, compact agent instructions, references, and eval cases.
+
+Validate the generated example:
+
+```bash
+skillet validate examples/effect
+skillet eval examples/effect --dry
+```

--- a/examples/effect/SKILL.md
+++ b/examples/effect/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: effect
+description: Guides production TypeScript work with current Effect APIs and explicit Effect architecture; use when implementing, reviewing, debugging, or refactoring Effect schemas, services, layers, config, schedules, caches, streams, HTTP clients, or tests, but not for non-Effect TypeScript or an explicitly older API surface.
+spec_hash: 42534c7af095
+---
+
+# Effect
+
+Ground every recommendation in the target project. Inspect repository instructions, the pinned `effect` version, installed package source, and local conventions before choosing APIs. Prefer project evidence over remembered signatures.
+
+## Choose the Relevant Guidance
+
+Read only the references needed for the task, and combine them when concerns overlap:
+
+- Schema, records, variants, brands, and typed errors: `references/SCHEMA.md`
+- Services, layers, modules, scope ownership, and `Effect.fn`: `references/SERVICES_LAYERS.md`
+- Configuration and providers: `references/CONFIG.md`
+- Schedules, retry, repeat, polling, and pacing: `references/SCHEDULING.md`
+- Cache, memoization, in-flight dedupe, and request batching: `references/CACHING.md`
+- Streams, queues, PubSub, SubscriptionRef, and long-lived consumers: `references/STREAMS.md`
+- HTTP clients, decoding, retries, and rate limits: `references/HTTP_CLIENTS.md`
+- Effect-aware tests, TestClock, layers, and synchronization: `references/TESTING.md`
+
+## Model Data and Failures
+
+- Use `Schema.Struct(...)` for application records.
+- Use brands for scalar IDs and constrained values.
+- Use tagged Schema variants and unions for values that cross boundaries.
+- Decode unknown boundary data with `Schema.decodeUnknownEffect(...)`.
+- Model expected failures with `Schema.TaggedErrorClass`.
+- Never use casts or throwing construction to skip validation at untrusted boundaries.
+
+## Build Explicit Services and Layers
+
+- Keep business rules in named workflows and services.
+- Represent dependencies explicitly in the Effect environment.
+- Build implementations with layers that own resource lifetime.
+- Keep HTTP and transport handlers focused on decoding, context, invocation, and response mapping.
+- Wrap public or non-trivial service methods with named `Effect.fn` calls.
+- Do not hide required authority, credentials, persistence, or transports behind defaults.
+
+## Choose Runtime Primitives by Meaning
+
+- Use `Config` for runtime configuration and override it with providers in tests.
+- Use `Schedule` for retry, repeat, polling, pacing, and backoff.
+- Use `Cache` or Effect memoization when their ownership and eviction model fit.
+- Use request batching only when the backend exposes a real batch operation.
+- Use Queue, PubSub, SubscriptionRef, and Stream according to producer, consumer, broadcast, and backpressure needs.
+- Keep long-lived fibers scoped to the layer or resource that owns them.
+
+## Keep Boundaries Truthful
+
+- Wrap HTTP clients, SDKs, CLIs, and external systems in named Effect boundaries.
+- Decode persisted and external values before treating them as domain data.
+- Preserve distinct transport, status, decode, and domain failures.
+- Retry only proven transient failures on idempotent operations with a bounded policy.
+- Keep exhausted failures visible unless the boundary has a real fallback.
+- Keep provider and network calls outside authoritative database transactions.
+
+## Test Deterministically
+
+- Use Effect-aware tests and explicit test layers.
+- Fork time-dependent work before advancing `TestClock`.
+- Coordinate concurrent work with Deferred, Queue, Latch, Ref, fibers, or explicit hooks.
+- Never add arbitrary real sleeps when deterministic synchronization can express the condition.
+
+## Preserve Types and Dependencies
+
+Solve missing requirements through explicit service and layer composition. Do not use `as any`, non-null assertions, broad cause recovery, `Layer.mergeAll`, `provideMerge`, or default authority merely to make code compile.
+
+## Before Editing
+
+1. Identify every Effect concern in the task.
+2. Read the matching references and project-local source.
+3. Choose APIs supported by the pinned version.
+4. Make the smallest architecture-preserving change.
+5. Run the project's typecheck and focused tests.

--- a/examples/effect/UPSTREAM.md
+++ b/examples/effect/UPSTREAM.md
@@ -1,0 +1,9 @@
+# Upstream Source
+
+- Repository: `kitlangton/skills`
+- Path: `skills/effect`
+- Commit: `0cace2ae0bd65e0cb03ab12860b62ae5e043f0df`
+- License: MIT
+- Retrieved: 2026-07-22
+
+The exact upstream skill snapshot is preserved under `original/`. The reference files at the example root are copied from that source under the MIT license. The generated spec, skill instructions, and eval cases were authored from the snapshot using Skillet's `spec.md` → `SKILL.md` → eval case workflow.

--- a/examples/effect/evals/cases/build-explicit-services-and-layers.yaml
+++ b/examples/effect/evals/cases/build-explicit-services-and-layers.yaml
@@ -1,0 +1,18 @@
+behavior: build-explicit-services-and-layers
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Refactor src/handler.ts so the billing workflow lives behind an explicit
+  service and layer. Keep the HTTP handler limited to transport concerns.
+checks:
+  - shell: '! git diff --quiet -- src/handler.ts'
+  - judge: >
+      Business logic is moved behind an explicit Effect service built by a
+      layer; configuration, provider, and persistence dependencies remain
+      visible; and the HTTP handler only decodes, invokes, and maps responses.
+timeout: 300

--- a/examples/effect/evals/cases/choose-native-runtime-primitives.yaml
+++ b/examples/effect/evals/cases/choose-native-runtime-primitives.yaml
@@ -1,0 +1,18 @@
+behavior: choose-native-runtime-primitives
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Replace the hand-written TTL and in-flight lookup maps in src/cache.ts with
+  the fitting Effect primitive. The backend only supports single-key lookups.
+checks:
+  - shell: '! git diff --quiet -- src/cache.ts'
+  - judge: >
+      The result uses a bounded Effect cache or fitting memoization primitive,
+      owns it at the correct lifetime, handles success and failure TTL
+      truthfully, deduplicates same-key lookups, and does not invent batching.
+timeout: 300

--- a/examples/effect/evals/cases/ground-advice-in-the-project.yaml
+++ b/examples/effect/evals/cases/ground-advice-in-the-project.yaml
@@ -1,0 +1,18 @@
+behavior: ground-advice-in-the-project
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Replace the hand-written polling loop in src/retry.ts with an Effect Schedule
+  supported by this project. Check the project-local API notes before editing.
+checks:
+  - shell: '! git diff --quiet -- src/retry.ts'
+  - judge: >
+      The implementation follows the repository instructions and local pinned
+      API notes, replaces the loop with a supported Schedule-based design, and
+      does not invent or assume an unsupported signature.
+timeout: 300

--- a/examples/effect/evals/cases/keep-external-boundaries-truthful.yaml
+++ b/examples/effect/evals/cases/keep-external-boundaries-truthful.yaml
@@ -1,0 +1,19 @@
+behavior: keep-external-boundaries-truthful
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Harden src/provider.ts. This GET is idempotent. Non-success responses and
+  malformed JSON must become typed failures, transient failures should use a
+  bounded retry policy, and exhausted failures must remain visible.
+checks:
+  - shell: '! git diff --quiet -- src/provider.ts'
+  - judge: >
+      The implementation separates transport, status, decode, and domain
+      failures; validates unknown response data; retries only bounded transient
+      failures for the idempotent request; and preserves exhausted failures.
+timeout: 300

--- a/examples/effect/evals/cases/load-guidance-by-concern.yaml
+++ b/examples/effect/evals/cases/load-guidance-by-concern.yaml
@@ -1,0 +1,18 @@
+behavior: load-guidance-by-concern
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Turn src/consumer.ts into an AuditConsumer service with a layer that owns the
+  long-lived stream consumer and stops it when the layer is released.
+checks:
+  - shell: '! git diff --quiet -- src/consumer.ts'
+  - judge: >
+      The result combines service/layer design with stream lifetime management:
+      it exposes an explicit service, starts consumption during layer
+      acquisition, and scopes the consumer fiber to the owning layer.
+timeout: 300

--- a/examples/effect/evals/cases/model-data-and-failures-with-schema.yaml
+++ b/examples/effect/evals/cases/model-data-and-failures-with-schema.yaml
@@ -1,0 +1,18 @@
+behavior: model-data-and-failures-with-schema
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  src/event.ts receives unknown webhook JSON. Replace the cast-based decoder
+  with Effect Schema for both event variants and a typed decoding failure.
+checks:
+  - shell: '! git diff --quiet -- src/event.ts'
+  - judge: >
+      The file models the external discriminator with Effect Schema, validates
+      unknown input effectfully, preserves an exhaustive typed union, maps
+      parse failure into a tagged typed error, and removes the unchecked cast.
+timeout: 300

--- a/examples/effect/evals/cases/preserve-types-and-visible-dependencies.yaml
+++ b/examples/effect/evals/cases/preserve-types-and-visible-dependencies.yaml
@@ -1,0 +1,18 @@
+behavior: preserve-types-and-visible-dependencies
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Fix src/wiring.ts so the InvoiceRepo requirement is provided correctly while
+  preserving the program's real success, error, and requirement types.
+checks:
+  - shell: '! git diff --quiet -- src/wiring.ts'
+  - judge: >
+      The missing InvoiceRepo requirement is satisfied through explicit
+      service/layer composition without unchecked casts, hidden default
+      authority, blind layer merging, or recovery that changes error semantics.
+timeout: 300

--- a/examples/effect/evals/cases/test-effect-code-deterministically.yaml
+++ b/examples/effect/evals/cases/test-effect-code-deterministically.yaml
@@ -1,0 +1,19 @@
+behavior: test-effect-code-deterministically
+fixture: effect-app
+setup: |
+  git init -q -b main
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+prompt: |
+  Rewrite src/worker-test.ts as a deterministic Effect test. The worker sleeps
+  before retrying and publishes in a background fiber; verify one publication
+  without waiting for real time.
+checks:
+  - shell: '! git diff --quiet -- src/worker-test.ts'
+  - judge: >
+      The test uses Effect-aware test execution, forks the time-dependent work
+      before advancing virtual time, coordinates readiness or publication with
+      deterministic primitives, and asserts one publication without real sleep.
+timeout: 300

--- a/examples/effect/evals/fixtures/effect-app/CONTRIBUTING.md
+++ b/examples/effect/evals/fixtures/effect-app/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Project Conventions
+
+- This project uses the Effect version pinned in `package.json`.
+- Inspect `vendor/effect-v4-api.md` before choosing an uncertain API.
+- Keep HTTP handlers transport-only and put provider workflows behind services.
+- Do not add dependencies for these refactors.

--- a/examples/effect/evals/fixtures/effect-app/package.json
+++ b/examples/effect/evals/fixtures/effect-app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "effect-v4-eval-app",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "effect": "4.0.0-beta.17"
+  }
+}

--- a/examples/effect/evals/fixtures/effect-app/src/cache.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/cache.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect"
+
+const entries = new Map<string, { value: string; expiresAt: number }>()
+const inFlight = new Map<string, Promise<string>>()
+
+export const resolveChannel = (channelId: string) =>
+  Effect.promise(async () => {
+    const cached = entries.get(channelId)
+    if (cached && cached.expiresAt > Date.now()) return cached.value
+    const pending = inFlight.get(channelId) ?? fetchChannel(channelId)
+    inFlight.set(channelId, pending)
+    const value = await pending
+    entries.set(channelId, { value, expiresAt: Date.now() + 60_000 })
+    inFlight.delete(channelId)
+    return value
+  })
+
+declare const fetchChannel: (channelId: string) => Promise<string>

--- a/examples/effect/evals/fixtures/effect-app/src/consumer.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/consumer.ts
@@ -1,0 +1,8 @@
+import { Effect, Stream } from "effect"
+
+export const startAuditConsumer = (events: Stream.Stream<string>) =>
+  Effect.gen(function* () {
+    yield* Effect.fork(
+      Stream.runForEach(events, (event) => Effect.logInfo(event)),
+    )
+  })

--- a/examples/effect/evals/fixtures/effect-app/src/event.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/event.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect"
+
+type Event =
+  | { readonly type: "started"; readonly runId: string }
+  | { readonly type: "finished"; readonly runId: string; readonly result: unknown }
+
+export class InvalidEvent extends Error {}
+
+export const decodeEvent = (input: unknown): Effect.Effect<Event, InvalidEvent> =>
+  Effect.succeed(input as Event)

--- a/examples/effect/evals/fixtures/effect-app/src/handler.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/handler.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect"
+
+export const postInvoice = (request: Request) =>
+  Effect.gen(function* () {
+    const input = (yield* Effect.promise(() => request.json())) as {
+      customerId: string
+      amount: number
+    }
+    const token = process.env.BILLING_TOKEN!
+    const response = yield* Effect.promise(() =>
+      fetch("https://billing.example/invoices", {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+        body: JSON.stringify(input),
+      }),
+    )
+    yield* saveInvoice(input.customerId, response.status)
+    return new Response(null, { status: 202 })
+  })
+
+declare const saveInvoice: (
+  customerId: string,
+  status: number,
+) => Effect.Effect<void>

--- a/examples/effect/evals/fixtures/effect-app/src/provider.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/provider.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect"
+
+export interface Account {
+  readonly id: string
+  readonly plan: "free" | "pro"
+}
+
+export const getAccount = (accountId: string): Effect.Effect<Account> =>
+  Effect.tryPromise(() =>
+    fetch(`https://provider.example/accounts/${accountId}`).then((response) =>
+      response.json() as Promise<Account>,
+    ),
+  ).pipe(Effect.retry({ times: 20 }))

--- a/examples/effect/evals/fixtures/effect-app/src/retry.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/retry.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+
+export const pollUntilReady = Effect.gen(function* () {
+  while (true) {
+    const ready = yield* checkReady
+    if (ready) return
+    yield* Effect.sleep("250 millis")
+  }
+})
+
+declare const checkReady: Effect.Effect<boolean>

--- a/examples/effect/evals/fixtures/effect-app/src/wiring.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/wiring.ts
@@ -1,0 +1,8 @@
+import { Effect, Layer } from "effect"
+
+export const program = loadInvoices.pipe(
+  Effect.provideMerge(Layer.empty),
+) as any
+
+declare const loadInvoices: Effect.Effect<ReadonlyArray<string>, Error, InvoiceRepo>
+declare class InvoiceRepo {}

--- a/examples/effect/evals/fixtures/effect-app/src/worker-test.ts
+++ b/examples/effect/evals/fixtures/effect-app/src/worker-test.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect"
+
+it("retries and publishes once", async () => {
+  await Effect.runPromise(runWorker)
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  expect(published).toHaveLength(1)
+})
+
+declare const runWorker: Effect.Effect<void>
+declare const published: ReadonlyArray<unknown>

--- a/examples/effect/evals/fixtures/effect-app/vendor/effect-v4-api.md
+++ b/examples/effect/evals/fixtures/effect-app/vendor/effect-v4-api.md
@@ -1,0 +1,13 @@
+# Local Effect API Notes
+
+This fixture models the project's pinned Effect API surface for the eval tasks.
+
+- `Schedule.spaced(duration)` creates a fixed-delay schedule.
+- `Cache.makeWith({ capacity, lookup, timeToLive })` supports exit-aware TTL.
+- `Schema.decodeUnknownEffect(schema)` validates unknown values in Effect.
+- `Schema.TaggedErrorClass(tag, fields)` models typed expected failures.
+- `Context.Service<Service, Shape>()(key)` defines an explicit service.
+- `Layer.effect(Service, effect)` builds a service implementation.
+- `Effect.fn(name)` names public and non-trivial workflows.
+- `Effect.forkScoped(effect)` ties a fiber to the current scope.
+- `TestClock.adjust(duration)` advances virtual time in tests.

--- a/examples/effect/original/LICENSE
+++ b/examples/effect/original/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kit Langton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/effect/original/SKILL.md
+++ b/examples/effect/original/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: effect
+description: |
+  Opinionated guide for building production TypeScript applications with Effect v4. Use when implementing Effect workflows, services, layers, schemas, configuration, schedules, caches, streams, HTTP clients, or tests.
+license: MIT
+compatibility: Requires Effect v4. Examples are reviewed against the version documented in this repository.
+---
+
+# Effect
+
+Use current Effect v4 APIs and the production defaults in this skill. Established project conventions still take precedence unless the task is explicitly changing them.
+
+## Source Rule
+
+Check these before guessing:
+
+- the nearest `AGENTS.md` and any project-local Effect practices doc
+- the project-pinned `effect` package source and version
+- current upstream Effect source when the installed package does not answer the question
+
+## Branch Chooser
+
+Read only the branch references that match the task.
+
+- Data models, schemas, brands, variants, optional keys, or decoders: read `references/SCHEMA.md`.
+- Services, module surfaces, layers, runtime wiring, errors, `Effect.fn`, or test services: read `references/SERVICES_LAYERS.md`.
+- Runtime config, env variables, `ConfigProvider`, or `layerConfig`: read `references/CONFIG.md`.
+- Retry, repeat, polling, backoff, jitter, rate-limit-aware policies, or pass loops: read `references/SCHEDULING.md`.
+- Memoization, per-key TTL caches, deduplicating concurrent lookups, or request batching: read `references/CACHING.md`.
+- Streams, event sources, async iterables, queues/pubsubs, pagination, backpressure, or stream consumers: read `references/STREAMS.md`.
+- Outgoing HTTP calls, Effect HttpClient, status handling, or HTTP rate limiting: read `references/HTTP_CLIENTS.md`.
+- Effect tests, time, sleeps, concurrency synchronization, or fakes: read `references/TESTING.md`.
+
+If a task spans several branches, read all matching files before editing.
+
+## Core Defaults
+
+- Compose workflows with `Effect.gen(function* () { ... })`.
+- Define public service methods and non-trivial internal service methods with `Effect.fn("Domain.operation")`.
+- Use `Effect.fnUntraced` only for internal helpers where stack-frame/span metadata is intentionally unnecessary.
+- Prefer `Context.Service` for application services when the codebase has not standardized on another current service-tag style.
+- Build real service implementations with `Layer.effect(Service, Effect.gen(...))` and return `Service.of({ ... })`.
+- Model records with `Schema.Struct(...)` plus a same-name `interface`.
+- Model typed Effect errors with `Schema.TaggedErrorClass`.
+- Read runtime config through `Config`, not direct `process.env` access in application logic.
+- Use `Schedule` for retry, repeat, polling, pacing, and backoff policies.
+- Use `Stream` for effectful sources that emit many values over time and need pull, backpressure, interruption, or transformation.
+- Prefer Effect HTTP client modules for outgoing HTTP in Effect applications when their typed errors, layers, and client transforms are useful.
+- Prefer Effect-aware tests, explicit layers, and deterministic synchronization over sleeps.
+- Prefer decoders and `schema.makeEffect(...)` at untrusted boundaries; reserve throwing `schema.make(...)` for trusted construction, and never use casts to skip validation.
+
+## Quick Selection Guide
+
+- Ordinary object record: `Schema.Struct(...)` plus same-name `interface`.
+- Scalar ID/value object: constrained branded schema.
+- Internal workflow decision or state: `Data.TaggedEnum<...>` plus `Data.taggedEnum<...>()` constructors and exhaustive `$match`.
+- Reusable boundary-crossing tagged variant: `Schema.TaggedStruct(...)` plus same-name `interface`.
+- Boundary-crossing tagged union: `Schema.TaggedUnion(...)` with `.cases`, `.guards`, and `.match`.
+- External/custom discriminator such as `type`: `Schema.Struct({ type: Schema.tag("variant"), ... })` plus `Schema.toTaggedUnion("type")` when union helpers are needed.
+- Expected typed failure: `Schema.TaggedErrorClass`.
+- Unknown boundary payload: `Schema.decodeUnknownEffect(...)`.
+- Service boundary: `Context.Service<Service, Interface>()(...)` plus `Layer.effect(...)` plus `Service.of(...)`.
+- Public or non-trivial internal service method: `Effect.fn("Domain.operation")`.
+- Runtime configuration: `Config` recipes read in layers; override with `ConfigProvider` in tests.
+- Event source: `Stream` consumed with `Stream.runForEach(...)` and forked with `Effect.forkScoped` in the owning layer.
+- Queue-backed event source: `Queue` for the producer boundary, `Stream.fromQueue(...)` for consumers.
+- Broadcast event source: `PubSub` / `Stream.fromPubSub(...)` or `SubscriptionRef` for latest-value state.
+- Polling worker: `runPass().pipe(Effect.repeat(Schedule.spaced(...)))`, with typed pass failures handled before repeat.
+- Retry transient operation: `Effect.retry(...)` / `Effect.retryOrElse(...)` with a bounded `Schedule`.
+- Keyed lookup cache with TTL and concurrent-lookup dedupe: prefer `Cache.make(...)` / exit-aware `Cache.makeWith(...)` when their lifecycle and eviction model fit.
+- Memoize a single effect result: `Effect.cached(...)` / `Effect.cachedWithTTL(...)`.
+- Batch N keys into one backend call (only when a real batch endpoint exists): `Effect.request(...)` + `RequestResolver`.
+- HTTP request in an Effect application: prefer Effect `HttpClient` plus request/response schema decoding.
+- HTTP transient retry: `HttpClient.retryTransient(...)`.
+- Time-sensitive test: `TestClock`, not real sleeping.
+- Concurrent/background test synchronization: `Deferred`, `Queue`, `Latch`, `Ref`, or explicit test hooks.
+
+## Boundary Rules
+
+- Keep HTTP handlers thin: decode input, read context, call services, map typed errors to transport responses.
+- Keep business rules in services or domain functions, not transport handlers.
+- Wrap HTTP clients, SDKs, CLIs, and external integrations in named effects at adapter boundaries.
+- Decode persisted rows with Schema or SQL-specific helpers when values are not trivially trusted.
+- Keep provider/network calls outside authoritative database transactions.
+- Catch or retry only when the current boundary has a truthful response.
+- Retry only when the operation has proven idempotency.
+- Let exhausted failures remain visible unless the boundary has a real fallback.
+
+## Do Nots
+
+- Do not use `as any`, non-null assertions, or unchecked casts to silence Effect typing problems.
+- Do not introduce `Schema.Class` or `Schema.TaggedClass` as default app data-modeling patterns.
+- Do not hand-roll `_tag` error classes when `Schema.TaggedErrorClass` fits.
+- Do not use cause-level recovery when typed-error recovery is enough.
+- Do not use `Layer.mergeAll(...)` or `provideMerge(...)` as blind make-it-compile tools.
+- Do not hide required application authority, credentials, persistence, transports, or external services behind `Context.Reference` defaults.
+- Do not add arbitrary `Effect.sleep(...)` to tests when a deterministic synchronization primitive is available.
+- Do not hand-roll Map/TTL/prune caches or in-flight dedupe when `effect/Cache` fits.

--- a/examples/effect/original/references/CACHING.md
+++ b/examples/effect/original/references/CACHING.md
@@ -1,0 +1,76 @@
+# Caching, Memoization, And Request Dedupe
+
+Use this when memoizing expensive lookups, caching per-key results with TTL, deduplicating concurrent identical calls, or considering request batching.
+
+Prefer `effect/Cache` over a `Map` + timestamp + prune-loop cache when its keyed memoization, TTL, capacity, lifecycle, and eviction semantics fit.
+
+## Core Rules
+
+- `Cache.make({ capacity, lookup, timeToLive })` caches per-key lookups with one fixed TTL for all entries.
+- `Cache.makeWith(lookup, { capacity, timeToLive(exit, key) })` computes TTL per entry from the lookup's `Exit` — the tool for "cache successes, not failures".
+- Concurrent `Cache.get` calls for the same missing key share one pending lookup — dedupe is built in; do not add your own in-flight tracking.
+- `capacity` is required and bounds the cache; stop writing manual prune/evict loops.
+- Return a zero TTL (`0` or `"0 millis"`) from `timeToLive` to avoid caching transient failures or degraded fallbacks without failing the caller. A short negative-cache TTL can be appropriate for stable failures such as not-found results.
+- `Cache.invalidate(cache, key)` / `Cache.refresh(cache, key)` handle explicit staleness; `Cache.has` checks without triggering a lookup.
+- Cache construction is effectful. Build the cache once in the owning layer/scope and share the handle; a cache built per call caches nothing.
+- For a single value (no key), use `Effect.cached(effect)` or `Effect.cachedWithTTL(effect, ttl)` instead of a one-key Cache.
+- For cached resources that need cleanup (connections, clients), use `ScopedCache`.
+
+## Exit-Aware TTL (cache successes, skip degraded results)
+
+```ts
+import { Cache, Duration, Effect, Exit } from "effect"
+
+const makeResolver = Effect.gen(function* () {
+  const cache = yield* Cache.makeWith(
+    (channelRef: string) => resolveUncached(channelRef), // never-failing, returns { where, cacheable }
+    {
+      capacity: 300,
+      timeToLive: (exit) =>
+        Exit.isSuccess(exit) && exit.value.cacheable ? "10 minutes" : Duration.zero,
+    },
+  )
+  return (channelRef: string) =>
+    Cache.get(cache, channelRef).pipe(Effect.map((resolved) => resolved.where))
+})
+```
+
+This replaces a hand-rolled `Map<string, { value, expiresAtMs }>` plus prune logic, and upgrades it: repeated rows pointing at the same key during one burst share a single provider call.
+
+## Expensive Client Acquisition Belongs In The Layer, Not The Lookup
+
+A cache cannot fix a lookup that pays a scoped acquisition per call, such as SDK client construction or authentication. Acquire clients once via the owning layer (`Layer.build` inside a `Layer.unwrap(Effect.gen(...))` composition, or a service dependency) so the cached lookup is a plain call:
+
+```ts
+// Bad: every cache miss acquires a fresh client
+const lookup = (id: string) =>
+  getRecord(id).pipe(Effect.provide(apiClientLayer(options)))
+
+// Good: client built once for the layer's lifetime; misses are one API call
+// Layer.build requires Scope.Scope; acquire this inside the owning layer's scope.
+const context = yield* Layer.build(apiClientLayer(options))
+const lookup = (id: string) => Context.get(context, ApiClient).getRecord(id)
+```
+
+## Request Batching (`Effect.request` + `RequestResolver`)
+
+Batching exists for backends with a real batch endpoint: the resolver receives an array of pending requests and can collapse them into one wire call.
+
+- Use it when the API can answer N keys in one call (SQL `IN (...)`, DataLoader-style endpoints, batch GET).
+- Do not reach for it when the backend only has per-item endpoints (most REST provider APIs): a batched resolver still loops one call per entry, so it buys nothing over `Effect.forEach(items, f, { concurrency })` plus `Cache` for dedupe/memoization.
+- `RequestResolver.batchN(resolver, n)` bounds batch size; `RequestResolver.makeGrouped` groups requests that must resolve through different targets.
+
+Selection guide:
+
+- Same key requested repeatedly over time → `Cache`.
+- Same key requested concurrently in one burst → `Cache` (shared pending lookup).
+- Many distinct keys, backend has a batch endpoint → `Effect.request` + `RequestResolver`.
+- Many distinct keys, per-item endpoint only → `Effect.forEach(..., { concurrency: n })`, optionally through a `Cache`.
+
+## Do Nots
+
+- Do not hand-roll Map/TTL/prune caches, in-flight dedupe maps, or LRU logic when `Cache` fits.
+- Choose failure TTLs by semantics. Skip transient failures and degraded fallbacks by default; bounded negative caching can protect an upstream from repeated stable failures.
+- Do not build a cache inside the request handler or per call — hoist it to the owning layer.
+- Do not adopt `RequestResolver` batching for per-item REST endpoints just because "batching" sounds faster.
+- Do not put scoped client acquisition inside the cache lookup; acquire once in the layer.

--- a/examples/effect/original/references/CONFIG.md
+++ b/examples/effect/original/references/CONFIG.md
@@ -1,0 +1,67 @@
+# Config
+
+Use this when reading runtime configuration, env vars, `.env` files, provider-specific settings, or writing `layerConfig(...)` helpers.
+
+Read runtime configuration through Effect `Config` recipes and provider layers, not direct `process.env` access inside application logic.
+
+```ts
+export const dataDirectoryConfig = Config.schema(
+  AbsolutePath,
+  "APP_DATA_DIR",
+)
+
+export const layerFromEnvironment = Layer.effect(
+  Configuration.Service,
+  Effect.gen(function* () {
+    const apiKey = yield* Config.redacted("API_KEY")
+    const optionalModel = yield* Config.option(Config.string("MODEL"))
+    const enabled = yield* Config.boolean("FEATURE_ENABLED").pipe(
+      Config.withDefault(false),
+    )
+
+    return Configuration.Service.of({ apiKey, optionalModel, enabled })
+  }),
+)
+```
+
+## Config Recipes
+
+- `Config<T>` is yieldable and reads the current `ConfigProvider` reference.
+- The default provider is `ConfigProvider.fromEnv()`.
+- Use `Config.redacted(...)` for credentials.
+- Use `Config.schema(...)` or `Config.mapOrFail(...)` for refined values.
+- Use `Config.option(...)` for semantic absence.
+- Use `Config.withDefault(...)` for missing-data defaults only; malformed values still fail.
+- Use `Config.orElse(...)` only when intentionally catching any config parse failure.
+- Use `Config.unwrap(...)` / `Config.Wrap<T>` for `layerConfig(...)` helpers.
+
+## Providers
+
+- Use `ConfigProvider.layer(provider)` to replace the active provider for an app or suite.
+- Use `ConfigProvider.layerAdd(provider)` for fallbacks; pass `{ asPrimary: true }` when the added provider must override the current provider.
+- Use `ConfigProvider.fromUnknown(...)` for deterministic test config.
+- Use `ConfigProvider.fromEnv(...)` for environment variables.
+- Use `ConfigProvider.constantCase` when camelCase schema keys should read `SCREAMING_SNAKE_CASE` env vars.
+- Use `ConfigProvider.nested(...)` to scope a provider under a prefix.
+- Treat `.env`, directory, and environment providers as startup/boundary sources, not business-workflow reads.
+
+## Layer Config Helpers
+
+Library-style layers often expose both concrete `layer(options)` and config-backed `layerConfig(options: Config.Wrap<Options>)`.
+
+```ts
+export const layerConfig = (
+  config: Config.Wrap<ClientOptions>,
+) =>
+  Layer.effect(
+    Client.Service,
+    Config.unwrap(config).pipe(
+      Effect.flatMap(makeClient),
+      Effect.map((client) => Client.Service.of(client)),
+    ),
+  )
+```
+
+Use this pattern when a service naturally supports runtime config while still allowing tests to pass concrete values.
+
+Use `Layer.succeed(AppConfiguration.Service, testConfig)` when the app already wraps environment config in an application service and the test does not need to exercise Config decoding itself.

--- a/examples/effect/original/references/HTTP_CLIENTS.md
+++ b/examples/effect/original/references/HTTP_CLIENTS.md
@@ -1,0 +1,101 @@
+# HTTP Clients
+
+Use this when writing outgoing HTTP calls, Effect HttpClient adapters, status classification, HTTP retries, or rate limiting.
+
+Use Effect HTTP client modules for outgoing HTTP in app/provider code:
+
+- `effect/unstable/http/HttpClient`
+- `effect/unstable/http/HttpClientRequest`
+- `effect/unstable/http/HttpClientResponse`
+- `effect/unstable/http/HttpClientError`
+
+Prefer Effect HttpClient in Effect application and provider code when its typed errors, layers, and transforms are useful. Raw `fetch` remains reasonable for browser or edge constraints, small adapters, platform transports, and libraries that intentionally avoid unstable Effect HTTP APIs.
+
+## Boundary Shape
+
+HTTP adapter methods should be named effects that own the full boundary:
+
+- construct request
+- attach auth and headers
+- execute request
+- classify status
+- decode response body
+- map transport/status/decode failures to typed domain errors
+- apply retry/rate-limit policy where idempotent
+
+Keep raw provider/network effects outside business services and database transactions.
+
+## Effect HttpClient
+
+Useful APIs:
+
+- `HttpClient.get(...)`, `post(...)`, `put(...)`, `patch(...)`, `del(...)`, `execute(...)` for service accessors.
+- `HttpClient.mapRequest(...)` / `mapRequestEffect(...)` for configured client transforms.
+- `HttpClientRequest.prependUrl(...)` for base URLs.
+- `HttpClientRequest.bearerToken(...)` for bearer auth.
+- `HttpClientRequest.acceptJson` for JSON accept headers.
+- `HttpClientRequest.bodyJson(...)` for effectful JSON body encoding.
+- `HttpClientRequest.schemaBodyJson(...)` for schema-backed JSON body encoding.
+- `HttpClient.filterStatusOk` / `HttpClientResponse.filterStatusOk` before decoding when non-2xx responses are failures.
+- `HttpClientResponse.schemaBodyJson(...)` for body-only decoding, `schemaJson(...)` for status/headers/body decoding, and `schemaNoBody(...)` for status/headers decoding.
+- `HttpClient.retryTransient(...)` for common transient HTTP failures.
+- `HttpClient.withRateLimiter(...)` for proactive pacing and learning from rate-limit headers. It requires a `RateLimiter` plus initial window, limit, and key options; it adds `RateLimiterError` to the error channel and retries `429` responses by default.
+
+## Retry And Rate Limits
+
+Use `HttpClient.retryTransient(...)` for common transient HTTP failures:
+
+- transport errors
+- timeouts
+- `408`
+- `429`
+- `500`
+- `502`
+- `503`
+- `504`
+
+Use `HttpClient.withRateLimiter(...)` when the client should proactively pace requests and learn from rate-limit / `Retry-After` headers.
+
+Use operation-level `Effect.retry(...)` when retry depends on domain-specific typed errors, provider payloads, or idempotency rules. Read `SCHEDULING.md` for custom schedules and `retryAfterMs` typed-provider patterns.
+
+## Raw Fetch Exception
+
+Use raw `fetch` deliberately when implementing a platform transport, adapting an API that cannot use Effect HttpClient, or targeting a runtime/library boundary where the unstable Effect HTTP modules are not an appropriate dependency.
+
+If a temporary raw `fetch` boundary is unavoidable, keep it inside an adapter service and still use Effect boundary discipline.
+
+```ts
+const request = Effect.fn("Provider.request")(function* (input: RequestInput) {
+  const response = yield* Effect.tryPromise({
+    try: (signal) => fetch(input.url, { signal, headers: input.headers }),
+    catch: (cause) => new ProviderError({ operation: "Provider.request", cause }),
+  })
+
+  if (!response.ok) {
+    return yield* Effect.fail(new ProviderRejected({
+      operation: "Provider.request",
+      status: response.status,
+    }))
+  }
+
+  const json = yield* Effect.tryPromise({
+    try: () => response.json(),
+    catch: (cause) => new ProviderError({ operation: "Provider.decodeJson", cause }),
+  })
+
+  return yield* Schema.decodeUnknownEffect(ResponseSchema)(json).pipe(
+    Effect.mapError((cause) =>
+      new ProviderError({ operation: "Provider.decodeResponse", cause }),
+    ),
+  )
+})
+```
+
+Guidance:
+
+- Prefer replacing this with Effect HttpClient before adding more behavior.
+- Wire `AbortSignal` from `Effect.tryPromise` into `fetch` when raw fetch is unavoidable.
+- Classify HTTP status before decoding successful payloads.
+- Decode unknown response bodies with Schema at the boundary.
+- Preserve provider evidence needed for diagnosis, but redact secrets and private payloads.
+- Apply retry only for idempotent operations.

--- a/examples/effect/original/references/SCHEDULING.md
+++ b/examples/effect/original/references/SCHEDULING.md
@@ -1,0 +1,135 @@
+# Scheduling And Retry
+
+Use this when writing retries, repeats, polling workers, backoff, jitter, rate-limit-aware policies, timeouts, or pass loops.
+
+Use `Schedule` for retry, polling, pacing, and repeated background work instead of hand-rolled `while (true)` loops with sleeps.
+
+## Core Rules
+
+- `Effect.retry(...)` retries typed failures; defects and interruptions are not retried.
+- `Effect.repeat(...)` repeats successful effects; failures stop repetition unless the pass handles them first.
+- The source effect runs once before the schedule is stepped.
+- `Schedule.recurs(3)` means three retries/repetitions after the initial run.
+- `Schedule.spaced(...)` waits after work completes.
+- `Schedule.fixed(...)` aligns executions to a cadence.
+- Use `Schedule.exponential(...)` or `Schedule.fibonacci(...)` for backoff.
+- Add `Schedule.jittered` to avoid synchronized retry storms.
+- Use `Schedule.recurs(...)` for a counter schedule or `Schedule.upTo({ times })` to bound a delay schedule.
+- Use `Schedule.tapInput(...)` to log retry inputs.
+- Use `Schedule.tap(...)` when full schedule metadata matters.
+- Use `Effect.retryOrElse(...)` when exhausted retries need a fallback/reporting effect.
+- Retry only at the narrowest boundary with proven idempotency.
+- Exhausted failures should remain visible unless the boundary has a truthful fallback.
+
+## Polling Workers
+
+Prefer typed pass failures over cause recovery.
+
+```ts
+const pass = runPass().pipe(
+  Effect.tapError((error) =>
+    Effect.logError("Worker.pass_failed", error),
+  ),
+  Effect.ignore,
+)
+
+const run = pass.pipe(
+  Effect.repeat(Schedule.spaced("1 second")),
+)
+```
+
+This shape says expected operational pass failures are logged and the worker continues. Defects still defect and can reach supervision.
+
+Use cause-level recovery only at supervision boundaries where the policy is truly "report non-interrupt failure and continue".
+
+```ts
+const logNonInterruptCauseAndContinue = (message: string) =>
+  Effect.catchCauseIf(
+    (cause) => !Cause.hasInterrupts(cause),
+    (cause) => Effect.logError(message, cause),
+  )
+```
+
+Do not catch causes just to make failures disappear. If only expected typed failures should be recoverable, use `Effect.catchIf(...)`, `Effect.catchFilter(...)`, `Effect.catchTag(...)`, or `Effect.retry(...)` on those typed errors instead.
+
+## Per-Item Failure Isolation
+
+For batch workers, catch expected item-level typed failures around each item so one bad item does not stall the batch.
+
+```ts
+yield* Effect.forEach(
+  items,
+  (item) =>
+    processItem(item).pipe(
+      Effect.tapError((error) =>
+        Effect.logError("Worker.item_failed", error).pipe(
+          Effect.annotateLogs({ itemId: item.id }),
+        ),
+      ),
+      Effect.ignore,
+    ),
+  { discard: true, concurrency: 5 },
+)
+```
+
+Only do this when retrying the item later is truthful or skipping the item is the product policy.
+
+## Reusable Retry Policy
+
+```ts
+const projectionRetrySchedule: Schedule.Schedule<unknown, ProjectionError> =
+  Schedule.exponential("100 millis").pipe(
+    Schedule.jittered,
+    Schedule.upTo({ times: 5 }),
+  )
+
+const reconcileWithRetry = (target: Target) =>
+  reconcile(target).pipe(
+    Effect.retryOrElse(
+      projectionRetrySchedule.pipe(
+        Schedule.tapInput((error) =>
+          Effect.logWarning("Agent.Projection.reconcile.retrying").pipe(
+            Effect.annotateLogs({ operation: error.operation }),
+          ),
+        ),
+      ),
+      (error) => Effect.logError("Agent.Projection.reconcile.stopped", error),
+    ),
+  )
+```
+
+Use this when the operation is idempotent and retry state is useful for logs or metrics.
+
+## Rate-Limit-Aware Typed Retry
+
+For provider errors that carry `retryAfterMs`, let the schedule use the larger of the backoff delay and the provider delay.
+
+```ts
+type RateLimited = {
+  readonly retryAfterMs?: number | undefined
+}
+
+const providerRetrySchedule: Schedule.Schedule<RateLimited, RateLimited> =
+  Schedule.exponential("200 millis").pipe(
+    Schedule.jittered,
+    Schedule.upTo({ times: 5 }),
+    Schedule.passthrough,
+    Schedule.modifyDelay(({ input, duration }) =>
+      Effect.succeed(
+        input.retryAfterMs === undefined
+          ? duration
+          : Duration.max(duration, Duration.millis(input.retryAfterMs)),
+      ),
+    ),
+  )
+```
+
+Use this for operation-level retries over typed provider errors. For Effect HttpClient-level 429 handling and proactive pacing, read `HTTP_CLIENTS.md`.
+
+## Timeouts And Delays
+
+- Use `Effect.timeout(...)` when the operation has a real deadline.
+- Use `Effect.delay(...)` when one operation should start later.
+- Use `Effect.sleep(...)` inside production workflows only when sleeping itself is the domain behavior.
+- Avoid manual sleep loops; use `Effect.repeat(...)` with `Schedule` for recurring work.
+- In tests, use `TestClock` rather than real time. Read `TESTING.md`.

--- a/examples/effect/original/references/SCHEMA.md
+++ b/examples/effect/original/references/SCHEMA.md
@@ -1,0 +1,130 @@
+# Schema And Data Modeling
+
+Use this when touching data models, DTOs, row schemas, wire contracts, brands, variants, optional fields, or decoders.
+
+## Records
+
+Default to `Schema.Struct(...)` plus a same-name `interface`.
+
+```ts
+export const User = Schema.Struct({
+  id: UserId,
+  name: Schema.NonEmptyString,
+  email: Schema.optionalKey(Schema.String),
+})
+
+export interface User extends Schema.Schema.Type<typeof User> {}
+```
+
+Guidance:
+
+- Add `.annotate({ identifier: "User" })` only when tooling consumes it: HTTP API, RPC, OpenAPI/JSON Schema, docs, diagnostics, or codegen.
+- Use `schema.make(...)` when construction is trusted.
+- Use `schema.makeEffect(...)` when construction failure should stay in the Effect error channel.
+- Decode unknown input at boundaries with `Schema.decodeUnknownEffect(...)` by default.
+- Use `Schema.decodeUnknownSync(...)` only in scripts, tests, or startup paths where throwing is acceptable.
+- Use `Schema.decodeUnknownOption(...)` only when mismatch details are intentionally discarded.
+- Use `Schema.decodeUnknownResult(...)` for pure code that wants explicit success/failure without Effect.
+
+## Field And Contract Reuse
+
+Reuse fields directly when contracts are semantically related.
+
+```ts
+export const CreateUserInput = Schema.Struct({
+  name: User.fields.name,
+  email: User.fields.email,
+})
+
+export const StoredUser = User.pipe(
+  Schema.fieldsAssign({
+    createdAt: Schema.DateTimeUtcFromString,
+  }),
+)
+```
+
+Guidance:
+
+- Use `.fields`, `Schema.fieldsAssign(...)`, and `.mapFields(...)` when contracts are genuinely related.
+- Use `Schema.encodeKeys(...)` when decoded TypeScript names differ from encoded wire/storage keys and naming is the only difference.
+- Keep explicit mapping when behavior, joins, validation, or domain translation is involved.
+- Use `Schema.extendTo(...)` sparingly for decoded-only derived fields.
+- Use field reuse to build small related contracts, not one oversized inheritance-by-schema object.
+
+## Optionality And Defaults
+
+- Use `Schema.optionalKey(...)` for absent JSON/storage keys.
+- Use `Schema.optional(...)` only when explicit `undefined` is part of the contract.
+- Use `Schema.NullOr`, `Schema.UndefinedOr`, or `Schema.NullishOr` only when nullish values are truly part of the encoded contract.
+- Keep normalized defaulted values as required fields and apply defaults in constructors/decoding.
+- Do not make domain values optional merely for construction convenience.
+
+## Nominal Values
+
+- Use constrained branded schemas for scalar IDs and value objects.
+- Use normal schema constraints before `Schema.brand(...)` for most code.
+- Reach for `Schema.fromBrand(...)` only when the project already models brands with `Brand` constructors or wants the check packaged with the brand constructor.
+
+## Variants
+
+```ts
+type Step = Data.TaggedEnum<{
+  Continue: { readonly cursor: number }
+  Finished: { readonly count: number }
+}>
+
+export const Step = Data.taggedEnum<Step>()
+
+const next = Step.Continue({ cursor: 10 })
+const label = Step.$match(next, {
+  Continue: ({ cursor }) => `continue at ${cursor}`,
+  Finished: ({ count }) => `finished ${count}`,
+})
+```
+
+```ts
+export const Event = Schema.TaggedUnion({
+  Started: { runId: RunId },
+  Finished: { runId: RunId, result: Schema.Json },
+})
+
+export type Event = typeof Event.Type
+
+const event = Event.cases.Started.make({ runId })
+const label = Event.match(event, {
+  Started: ({ runId }) => `started ${runId}`,
+  Finished: ({ runId }) => `finished ${runId}`,
+})
+```
+
+Guidance:
+
+- Use `Data.TaggedEnum` for internal control-flow algebras; it provides constructors, `$is`, and exhaustive `$match`. Do not add a Schema solely to obtain these utilities.
+- Use `Schema.TaggedStruct` for the ordinary Effect-owned `_tag` variant.
+- Use `Schema.TaggedUnion` when the union needs decoding, encoding, persistence, wire validation, JSON Schema derivation, or schema composition.
+- Prefer a principled split over forcing one representation everywhere: Data internally, Schema at boundaries.
+- Use `Schema.tag(...)` when an external contract has a custom discriminator field such as `type` or `kind`; combine those structs with `Schema.toTaggedUnion("type")` when union helpers are needed.
+- If the encoded contract omits the discriminant, use `Schema.tagDefaultOmit(...)` deliberately.
+- Avoid `Schema.Class` and `Schema.TaggedClass` for new data models.
+
+## Errors
+
+`Schema.TaggedErrorClass` is the explicit class exception for typed Effect errors.
+
+```ts
+export class PersistenceError extends Schema.TaggedErrorClass<PersistenceError>()(
+  "UserRepo.PersistenceError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+```
+
+Guidance:
+
+- Map infrastructure failures into domain-specific tagged errors at service boundaries.
+- Include operation labels when they help diagnose adapter, persistence, provider, or transport failures.
+- Use schema unions for public API or transport error surfaces.
+- Use `Schema.Defect()` for defect-like payloads.
+- Preserve interruption when catching broad causes at ingress, worker, or stream boundaries.

--- a/examples/effect/original/references/SERVICES_LAYERS.md
+++ b/examples/effect/original/references/SERVICES_LAYERS.md
@@ -1,0 +1,168 @@
+# Services, Layers, And Modules
+
+Use this when defining service tags, module surfaces, layer implementations, runtime wiring, typed errors, or `Effect.fn` operation boundaries.
+
+## Module Surface
+
+One opinionated application-module style uses file-local role names and one canonical ES module namespace projection. Follow the existing codebase's module style when it has one; this convention is not required by Effect.
+
+```ts
+export interface Interface {
+  readonly get: (id: UserId) => Effect.Effect<User, NotFound | PersistenceError>
+}
+
+export class Service extends Context.Service<Service, Interface>()(
+  "@app/UserRepo",
+) {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const get = Effect.fn("UserRepo.get")(function* (id: UserId) {
+      // ...
+    })
+
+    return Service.of({ get })
+  }),
+)
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
+  "UserRepo.NotFound",
+  { id: UserId },
+) {}
+
+export * as UserRepo from "./user-repo.js"
+```
+
+Consumers use the module namespace.
+
+```ts
+import { UserRepo } from "./user-repo.js"
+
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo.Service
+  return yield* repo.get(id)
+})
+```
+
+The self-export is deliberate. It lets the file remain the module while giving every consumer the same domain-first name, without a TypeScript `namespace`, wrapper object, or repeated consumer-side aliases.
+
+```ts
+// Sibling module: import the owning leaf directly.
+import { UserRepo } from "./user-repo.js"
+
+// Folder or package barrel: relay the identity established by the leaf.
+export { UserRepo } from "./user-repo.js"
+```
+
+Guidance:
+
+- Do not name the tag class `UserRepo` inside `user-repo.ts`; the module namespace is the domain name.
+- In this module style, single-file modules self-export their canonical namespace at the bottom: `export * as UserRepo from "./user-repo.js"`.
+- Sibling modules import that namespace from the owning leaf; they do not import through their own aggregate barrel.
+- Folder and package barrels relay established leaf identities with `export { UserRepo } from "./user-repo.js"`.
+- The resulting `UserRepo.UserRepo === UserRepo` self-reference is unusual. Use this pattern only where the runtime and toolchain support it; otherwise use named exports or a separate barrel.
+- Export only intentional surface; keep local schemas, row codecs, helpers, and implementation details unexported.
+- Do not introduce TypeScript `namespace` declarations for organization.
+- Use a named service class such as `class UserRepo extends Context.Service...` when an external library or existing codebase does not use module namespace style.
+
+## Layer Constructors
+
+Choose the layer constructor that matches the thing produced.
+
+```ts
+Layer.succeed(Service, impl)       // already-built service
+Layer.sync(Service, () => impl)    // lazy synchronous service
+Layer.effect(Service, makeEffect)  // effectful service acquisition
+```
+
+Guidance:
+
+- Default real implementations to `Layer.effect(Service, Effect.gen(...))`.
+- Use `Layer.effectContext(...)` when one acquisition intentionally supplies multiple services, especially first-class test stubs or one client backing several service tags.
+- Use `Layer.unwrap(...)` when config or runtime discovery chooses/builds the layer.
+- Use `Layer.fresh(...)` or `Effect.provide(layer, { local: true })` only when a test or operation needs isolated acquisition.
+- Use `Context.Reference` rarely, only for ambient/defaultable runtime references where a safe default is real.
+
+## Long-Lived Work
+
+A layer that starts a stream, listener, worker, subscription, or forever loop must fork that work into the layer scope. Layer acquisition must complete.
+
+```ts
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const events = yield* Events.Service
+
+    yield* events.stream.pipe(
+      Stream.runForEach(handleEvent),
+      Effect.forkScoped,
+    )
+  }),
+)
+```
+
+Guidance:
+
+- Use `Effect.forkScoped`, `FiberSet`, or `FiberMap` for scoped background work.
+- Do not run forever work inline during layer acquisition.
+- Do not expose public `start` methods unless the domain explicitly needs manual lifecycle control.
+
+## Runtime Wiring
+
+- Use `Layer.provide(...)` to hide an implementation dependency.
+- Use `Layer.provideMerge(...)` only when the dependency should remain exposed for downstream consumers.
+- Use `Layer.mergeAll(...)` for independent exposed layers.
+- Prefer flat, topologically sorted runtime layer values with named subgraphs.
+- Avoid using `provideMerge` as a blind make-it-compile tool.
+- Avoid hiding important authority or lifecycle dependencies behind broad invisible provisioning.
+
+## Effect.fn
+
+Use extra `Effect.fn(...)` arguments for wrappers that apply to the whole function call. Each transform receives `(effect, ...originalArgs)`.
+
+```ts
+const readAttachment = Effect.fn("Attachment.read")(
+  function* (ref: AttachmentRef) {
+    return yield* api.read(ref)
+  },
+  (effect, ref) =>
+    effect.pipe(
+      attachmentError("Attachment.read", { attachmentId: ref.id }),
+    ),
+)
+```
+
+Good whole-function transforms:
+
+- error classification
+- localized recovery
+- logging annotations
+- spans
+- retry
+- timeout
+- ensuring cleanup
+- small local provisioning
+- result mapping
+
+Guidance:
+
+- Keep the generator body focused on the core workflow.
+- Use transforms when the wrapper needs original arguments.
+- Do not build long clever pipelines; one or two transforms is usually enough.
+- Do not use this for local branch-level handling inside the workflow.
+
+## Operation Error Helpers
+
+For boundary errors with operation labels, prefer a shared curried `mapError` helper over hand-writing wrappers in every module.
+
+```ts
+const persistenceError = operationError(PersistenceError.make)
+
+const row = yield* query.pipe(
+  persistenceError("UserRepository.findById"),
+)
+```
+
+Name the local helper after the error it produces, such as `persistenceError`, `projectionError`, or `processingError`. Use `Effect.fn(...)` and spans for observability in addition to payload labels, not instead of them.

--- a/examples/effect/original/references/STREAMS.md
+++ b/examples/effect/original/references/STREAMS.md
@@ -1,0 +1,135 @@
+# Streams
+
+Use this when working with `Stream`, event sources, async iterables, queue/pubsub-backed streams, pagination, backpressure, throttling, debouncing, or long-lived stream consumers.
+
+## Mental Model
+
+`Stream<A, E, R>` is an effectful source that can emit many `A` values over time, fail with `E`, and require services `R`. Streams are pull-based and backpressured; consumption controls demand.
+
+Use streams for sources that are naturally many-valued and time-ordered:
+
+- gateway events
+- provider callbacks adapted through queues
+- subscription/event logs
+- paginated APIs
+- file/stdin/platform streams
+- scheduled ticks when values matter
+- pipelines with filtering, mapping, buffering, throttling, or bounded concurrent processing
+
+Do not use streams just to loop forever. For one repeated effect with no emitted values, use `Effect.repeat(...)` with `Schedule`; read `SCHEDULING.md`.
+
+## Source Chooser
+
+- In-memory values: `Stream.make(...)` or `Stream.fromIterable(...)`.
+- Test fixtures: `Stream.fromIterable(...)`, often with `Stream.concat(Stream.never)` for an open subscription.
+- Queue-backed callback boundary: `Queue` plus `Stream.fromQueue(...)`.
+- Broadcast events: `PubSub` plus `Stream.fromPubSub(...)`.
+- Latest-value state plus updates: `SubscriptionRef`.
+- Schedule-generated ticks/values: `Stream.fromSchedule(...)`.
+- Paginated pull APIs: `Stream.paginate(...)`; its step function is already effectful, returning `Effect<[chunk, Option<nextState>]>`.
+- Async iterable/platform source: `Stream.fromAsyncIterable(...)` when no native Effect source exists.
+- Effect that produces a stream after reading services/config: `Stream.unwrap(...)`.
+
+## Transformation Chooser
+
+- Pure transformation: `Stream.map(...)`.
+- Effectful transformation: `Stream.mapEffect(...)`.
+- Bounded concurrent effectful transformation: `Stream.mapEffect(fn, { concurrency })`.
+- Drop ordering when order is irrelevant and latency matters: `Stream.mapEffect(fn, { concurrency, unordered: true })`.
+- One input to zero/many outputs: `Stream.flatMap(...)`.
+- Multiple inner streams concurrently: `Stream.flatMap(fn, { concurrency })`.
+- Keep only matching values: `Stream.filter(...)` / `Stream.filterEffect(...)`.
+- Stateful transformation: `Stream.mapAccum(...)` / `Stream.mapAccumEffect(...)`.
+- Paginated pull-to-pages: prefer `Stream.paginate(...)` over hand-rolled loops. There is no separate `Stream.paginateEffect`.
+
+## Consumption Chooser
+
+- Side-effecting consumer: `Stream.runForEach(...)`.
+- Ignore elements but run the stream: `Stream.runDrain`.
+- Tests/small finite streams: `Stream.runCollect`.
+- First N values in tests: `Stream.take(n)` plus `Stream.runCollect`.
+- Fold into a value: `Stream.runFold(...)`.
+- Long-lived consumer in a layer: `stream.pipe(Stream.runForEach(...), Effect.forkScoped)`.
+
+Avoid `Stream.runCollect` on unbounded or production event streams.
+
+## Long-Lived Consumers
+
+Own long-lived stream consumers in layers and fork them into the layer scope.
+
+```ts
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const gateway = yield* Gateway.Service
+
+    yield* gateway.events.pipe(
+      Stream.filter(isMessageEvent),
+      Stream.runForEach(handleEvent),
+      Effect.forkScoped,
+    )
+  }),
+)
+```
+
+Guidance:
+
+- Let the layer own the stream lifetime.
+- Use `Effect.forkScoped` for the ordinary case.
+- If methods need to fork work into the layer lifetime, capture `Scope.Scope` during layer acquisition and use `Effect.forkIn(scope)` internally. Do not expose the scope as public service API.
+- Preserve stream failures unless the owning boundary has a truthful recovery policy.
+
+## Queues, PubSub, And SubscriptionRef
+
+- Use `Queue` when each event/item should be consumed by one consumer or worker.
+- Use `PubSub` when every subscriber should see every event.
+- Use `SubscriptionRef` when consumers need the current value and a stream of changes.
+- Expose a `Stream` from service interfaces when callers should consume events, not push into the queue.
+- Keep producer queues/private refs inside the implementation or test service.
+
+Good service shape:
+
+```ts
+export interface Interface {
+  readonly events: Stream.Stream<ProviderEvent, ProviderError>
+  readonly status: Stream.Stream<ProviderStatus>
+}
+```
+
+Implementation can use private `Queue` / `SubscriptionRef`; consumers see streams.
+
+## Backpressure And Buffers
+
+Prefer natural stream backpressure first.
+
+Use `Stream.buffer(...)` only when producer and consumer should decouple.
+
+- `strategy: "suspend"`: apply backpressure when full.
+- `strategy: "dropping"`: drop new values when full.
+- `strategy: "sliding"`: keep the latest values by dropping old ones.
+- `capacity: "unbounded"`: rare; use only when growth is bounded elsewhere.
+
+Use `Stream.debounce(...)` for quiet-period behavior and `Stream.throttle(...)` / `Stream.throttleEffect(...)` for rate-shaped streams.
+
+## Error Handling
+
+- Prefer typed stream errors over defects.
+- Use `Stream.mapError(...)` to translate errors at boundaries.
+- Use `Stream.catchIf(...)`, `Stream.catchTag(...)`, or `Stream.catchFilter(...)` for typed recovery.
+- Use `Stream.catchCause(...)` only at explicit supervision boundaries.
+- Do not hide stream defects by default; let them reach the owning layer/runtime unless the stream is explicitly best-effort.
+
+## Keyed Concurrency
+
+For streams of work keyed by session/channel/id, prefer a named helper over ad hoc maps of fibers.
+
+If the codebase already has a keyed-run helper (for example a `runForEachKeyed` that runs different keys concurrently while serializing each key and coalescing pending values into one latest-value rerun), use it. Otherwise build one named helper with `FiberMap` rather than scattering fiber bookkeeping through consumers.
+
+Use this for projection/reconciliation streams where each key needs ordered processing but different keys can run in parallel.
+
+## Tests
+
+- Use `Stream.fromIterable(...)` for finite fixtures.
+- Use `Stream.empty` for no events.
+- Use `Stream.fromQueue(...)` with a test-owned `Queue` when the test needs to drive events interactively.
+- Use `Stream.take(n)` plus `Stream.runCollect` for finite assertions.
+- Avoid real sleeps; coordinate with `Deferred`, `Queue`, `Latch`, and `TestClock`.

--- a/examples/effect/original/references/TESTING.md
+++ b/examples/effect/original/references/TESTING.md
@@ -1,0 +1,118 @@
+# Testing
+
+Use this when writing Effect tests, tests involving time, retry, schedules, concurrency, workers, services, fakes, or config.
+
+## Defaults
+
+- Use `it.effect` by default.
+- Use `it.live` only when real time or live runtime services are the behavior under test.
+- Use test layers and `ConfigProvider` rather than global mutation.
+- Use `TestClock.setTime` / `TestClock.adjust` for sleeps, schedules, retries, leases, and timeouts.
+- Fork sleeping effects before advancing `TestClock`.
+- Avoid arbitrary `Effect.sleep(...)` in tests; it usually makes tests slow and flaky.
+- Assert typed failures, rollback, interruption, finalization, retry bounds, idempotency, concurrency laws, and malformed persistence where relevant.
+
+```ts
+it.effect("finds a user", () =>
+  Effect.gen(function* () {
+    const users = yield* UserRepo.Service
+    const result = yield* users.find(UserId.make("u1"))
+    expect(Option.isSome(result)).toBe(true)
+  }).pipe(Effect.provide(UserRepo.testLayer)),
+)
+```
+
+## Synchronization Instead Of Sleeps
+
+- Use `Deferred` for one-shot readiness/completion signals.
+- Use `Queue` for handing test-controlled work or observed events across fibers.
+- Use `Latch` for reusable open/close coordination gates.
+- Use `Ref` for shared test observation state.
+- Use explicit test hooks when the production boundary can expose a deterministic synchronization point.
+
+```ts
+it.effect("publishes exactly once", () =>
+  Effect.gen(function* () {
+    const published = yield* Queue.unbounded<Message>()
+    const ready = yield* Deferred.make<void>()
+
+    const runWorker = makeWorker({
+      onReady: () => Deferred.succeed(ready, undefined),
+      onPublish: (message) => Queue.offer(published, message),
+    })
+
+    yield* runWorker.pipe(
+      Effect.forkScoped,
+    )
+
+    yield* Deferred.await(ready)
+    const message = yield* Queue.take(published)
+
+    expect(message).toEqual(expectedMessage)
+  }),
+)
+```
+
+## First-Class App Test Stubs
+
+Use `TestInterface extends Interface`, `TestService`, and `testLayer` for reusable/stateful fakes.
+
+```ts
+export interface Interface {
+  readonly send: (message: Message) => Effect.Effect<void, SendError>
+}
+
+export class Service extends Context.Service<Service, Interface>()(
+  "@app/Notifier",
+) {}
+
+export interface TestInterface extends Interface {
+  readonly sentMessages: () => Effect.Effect<ReadonlyArray<Message>>
+  readonly failNextSend: (error: SendError) => Effect.Effect<void>
+}
+
+export class TestService extends Context.Service<TestService, TestInterface>()(
+  "@app/Notifier/Test",
+) {}
+
+export const testLayer = Layer.effectContext(
+  Effect.gen(function* () {
+    const sent = yield* Ref.make<ReadonlyArray<Message>>([])
+    const nextFailure = yield* Ref.make<Option.Option<SendError>>(Option.none())
+
+    const service = TestService.of({
+      send: Effect.fn("Notifier.Test.send")(function* (message) {
+        const failure = yield* Ref.getAndSet(nextFailure, Option.none())
+        if (Option.isSome(failure)) return yield* Effect.fail(failure.value)
+        yield* Ref.update(sent, (messages) => [...messages, message])
+      }),
+      sentMessages: Effect.fn("Notifier.Test.sentMessages")(function* () {
+        return yield* Ref.get(sent)
+      }),
+      failNextSend: Effect.fn("Notifier.Test.failNextSend")(function* (error) {
+        yield* Ref.set(nextFailure, Option.some(error))
+      }),
+    })
+
+    return Context.empty().pipe(
+      Context.add(Service, service),
+      Context.add(TestService, service),
+    )
+  }),
+)
+```
+
+Guidance:
+
+- The same object should back both the real `Service` tag and `TestService` tag.
+- Production code depends only on the real service tag.
+- Tests use `TestService` for control and inspection.
+- Use function-valued service members, including zero-argument operations, so `Effect.fn` fits naturally.
+- Use `Layer.succeed` for complete dead-simple static test implementations.
+- Use `Layer.mock` only for tiny local partial mocks where omitted members should fail loudly if used.
+
+## Config In Tests
+
+Use `ConfigProvider.layer(ConfigProvider.fromUnknown(...))` when the test should exercise Config decoding.
+
+Use `Layer.succeed(AppConfiguration.Service, config)` when the app wraps decoded config in its own service and the test does not need to exercise env decoding.

--- a/examples/effect/references/CACHING.md
+++ b/examples/effect/references/CACHING.md
@@ -1,0 +1,76 @@
+# Caching, Memoization, And Request Dedupe
+
+Use this when memoizing expensive lookups, caching per-key results with TTL, deduplicating concurrent identical calls, or considering request batching.
+
+Prefer `effect/Cache` over a `Map` + timestamp + prune-loop cache when its keyed memoization, TTL, capacity, lifecycle, and eviction semantics fit.
+
+## Core Rules
+
+- `Cache.make({ capacity, lookup, timeToLive })` caches per-key lookups with one fixed TTL for all entries.
+- `Cache.makeWith(lookup, { capacity, timeToLive(exit, key) })` computes TTL per entry from the lookup's `Exit` — the tool for "cache successes, not failures".
+- Concurrent `Cache.get` calls for the same missing key share one pending lookup — dedupe is built in; do not add your own in-flight tracking.
+- `capacity` is required and bounds the cache; stop writing manual prune/evict loops.
+- Return a zero TTL (`0` or `"0 millis"`) from `timeToLive` to avoid caching transient failures or degraded fallbacks without failing the caller. A short negative-cache TTL can be appropriate for stable failures such as not-found results.
+- `Cache.invalidate(cache, key)` / `Cache.refresh(cache, key)` handle explicit staleness; `Cache.has` checks without triggering a lookup.
+- Cache construction is effectful. Build the cache once in the owning layer/scope and share the handle; a cache built per call caches nothing.
+- For a single value (no key), use `Effect.cached(effect)` or `Effect.cachedWithTTL(effect, ttl)` instead of a one-key Cache.
+- For cached resources that need cleanup (connections, clients), use `ScopedCache`.
+
+## Exit-Aware TTL (cache successes, skip degraded results)
+
+```ts
+import { Cache, Duration, Effect, Exit } from "effect"
+
+const makeResolver = Effect.gen(function* () {
+  const cache = yield* Cache.makeWith(
+    (channelRef: string) => resolveUncached(channelRef), // never-failing, returns { where, cacheable }
+    {
+      capacity: 300,
+      timeToLive: (exit) =>
+        Exit.isSuccess(exit) && exit.value.cacheable ? "10 minutes" : Duration.zero,
+    },
+  )
+  return (channelRef: string) =>
+    Cache.get(cache, channelRef).pipe(Effect.map((resolved) => resolved.where))
+})
+```
+
+This replaces a hand-rolled `Map<string, { value, expiresAtMs }>` plus prune logic, and upgrades it: repeated rows pointing at the same key during one burst share a single provider call.
+
+## Expensive Client Acquisition Belongs In The Layer, Not The Lookup
+
+A cache cannot fix a lookup that pays a scoped acquisition per call, such as SDK client construction or authentication. Acquire clients once via the owning layer (`Layer.build` inside a `Layer.unwrap(Effect.gen(...))` composition, or a service dependency) so the cached lookup is a plain call:
+
+```ts
+// Bad: every cache miss acquires a fresh client
+const lookup = (id: string) =>
+  getRecord(id).pipe(Effect.provide(apiClientLayer(options)))
+
+// Good: client built once for the layer's lifetime; misses are one API call
+// Layer.build requires Scope.Scope; acquire this inside the owning layer's scope.
+const context = yield* Layer.build(apiClientLayer(options))
+const lookup = (id: string) => Context.get(context, ApiClient).getRecord(id)
+```
+
+## Request Batching (`Effect.request` + `RequestResolver`)
+
+Batching exists for backends with a real batch endpoint: the resolver receives an array of pending requests and can collapse them into one wire call.
+
+- Use it when the API can answer N keys in one call (SQL `IN (...)`, DataLoader-style endpoints, batch GET).
+- Do not reach for it when the backend only has per-item endpoints (most REST provider APIs): a batched resolver still loops one call per entry, so it buys nothing over `Effect.forEach(items, f, { concurrency })` plus `Cache` for dedupe/memoization.
+- `RequestResolver.batchN(resolver, n)` bounds batch size; `RequestResolver.makeGrouped` groups requests that must resolve through different targets.
+
+Selection guide:
+
+- Same key requested repeatedly over time → `Cache`.
+- Same key requested concurrently in one burst → `Cache` (shared pending lookup).
+- Many distinct keys, backend has a batch endpoint → `Effect.request` + `RequestResolver`.
+- Many distinct keys, per-item endpoint only → `Effect.forEach(..., { concurrency: n })`, optionally through a `Cache`.
+
+## Do Nots
+
+- Do not hand-roll Map/TTL/prune caches, in-flight dedupe maps, or LRU logic when `Cache` fits.
+- Choose failure TTLs by semantics. Skip transient failures and degraded fallbacks by default; bounded negative caching can protect an upstream from repeated stable failures.
+- Do not build a cache inside the request handler or per call — hoist it to the owning layer.
+- Do not adopt `RequestResolver` batching for per-item REST endpoints just because "batching" sounds faster.
+- Do not put scoped client acquisition inside the cache lookup; acquire once in the layer.

--- a/examples/effect/references/CONFIG.md
+++ b/examples/effect/references/CONFIG.md
@@ -1,0 +1,67 @@
+# Config
+
+Use this when reading runtime configuration, env vars, `.env` files, provider-specific settings, or writing `layerConfig(...)` helpers.
+
+Read runtime configuration through Effect `Config` recipes and provider layers, not direct `process.env` access inside application logic.
+
+```ts
+export const dataDirectoryConfig = Config.schema(
+  AbsolutePath,
+  "APP_DATA_DIR",
+)
+
+export const layerFromEnvironment = Layer.effect(
+  Configuration.Service,
+  Effect.gen(function* () {
+    const apiKey = yield* Config.redacted("API_KEY")
+    const optionalModel = yield* Config.option(Config.string("MODEL"))
+    const enabled = yield* Config.boolean("FEATURE_ENABLED").pipe(
+      Config.withDefault(false),
+    )
+
+    return Configuration.Service.of({ apiKey, optionalModel, enabled })
+  }),
+)
+```
+
+## Config Recipes
+
+- `Config<T>` is yieldable and reads the current `ConfigProvider` reference.
+- The default provider is `ConfigProvider.fromEnv()`.
+- Use `Config.redacted(...)` for credentials.
+- Use `Config.schema(...)` or `Config.mapOrFail(...)` for refined values.
+- Use `Config.option(...)` for semantic absence.
+- Use `Config.withDefault(...)` for missing-data defaults only; malformed values still fail.
+- Use `Config.orElse(...)` only when intentionally catching any config parse failure.
+- Use `Config.unwrap(...)` / `Config.Wrap<T>` for `layerConfig(...)` helpers.
+
+## Providers
+
+- Use `ConfigProvider.layer(provider)` to replace the active provider for an app or suite.
+- Use `ConfigProvider.layerAdd(provider)` for fallbacks; pass `{ asPrimary: true }` when the added provider must override the current provider.
+- Use `ConfigProvider.fromUnknown(...)` for deterministic test config.
+- Use `ConfigProvider.fromEnv(...)` for environment variables.
+- Use `ConfigProvider.constantCase` when camelCase schema keys should read `SCREAMING_SNAKE_CASE` env vars.
+- Use `ConfigProvider.nested(...)` to scope a provider under a prefix.
+- Treat `.env`, directory, and environment providers as startup/boundary sources, not business-workflow reads.
+
+## Layer Config Helpers
+
+Library-style layers often expose both concrete `layer(options)` and config-backed `layerConfig(options: Config.Wrap<Options>)`.
+
+```ts
+export const layerConfig = (
+  config: Config.Wrap<ClientOptions>,
+) =>
+  Layer.effect(
+    Client.Service,
+    Config.unwrap(config).pipe(
+      Effect.flatMap(makeClient),
+      Effect.map((client) => Client.Service.of(client)),
+    ),
+  )
+```
+
+Use this pattern when a service naturally supports runtime config while still allowing tests to pass concrete values.
+
+Use `Layer.succeed(AppConfiguration.Service, testConfig)` when the app already wraps environment config in an application service and the test does not need to exercise Config decoding itself.

--- a/examples/effect/references/HTTP_CLIENTS.md
+++ b/examples/effect/references/HTTP_CLIENTS.md
@@ -1,0 +1,101 @@
+# HTTP Clients
+
+Use this when writing outgoing HTTP calls, Effect HttpClient adapters, status classification, HTTP retries, or rate limiting.
+
+Use Effect HTTP client modules for outgoing HTTP in app/provider code:
+
+- `effect/unstable/http/HttpClient`
+- `effect/unstable/http/HttpClientRequest`
+- `effect/unstable/http/HttpClientResponse`
+- `effect/unstable/http/HttpClientError`
+
+Prefer Effect HttpClient in Effect application and provider code when its typed errors, layers, and transforms are useful. Raw `fetch` remains reasonable for browser or edge constraints, small adapters, platform transports, and libraries that intentionally avoid unstable Effect HTTP APIs.
+
+## Boundary Shape
+
+HTTP adapter methods should be named effects that own the full boundary:
+
+- construct request
+- attach auth and headers
+- execute request
+- classify status
+- decode response body
+- map transport/status/decode failures to typed domain errors
+- apply retry/rate-limit policy where idempotent
+
+Keep raw provider/network effects outside business services and database transactions.
+
+## Effect HttpClient
+
+Useful APIs:
+
+- `HttpClient.get(...)`, `post(...)`, `put(...)`, `patch(...)`, `del(...)`, `execute(...)` for service accessors.
+- `HttpClient.mapRequest(...)` / `mapRequestEffect(...)` for configured client transforms.
+- `HttpClientRequest.prependUrl(...)` for base URLs.
+- `HttpClientRequest.bearerToken(...)` for bearer auth.
+- `HttpClientRequest.acceptJson` for JSON accept headers.
+- `HttpClientRequest.bodyJson(...)` for effectful JSON body encoding.
+- `HttpClientRequest.schemaBodyJson(...)` for schema-backed JSON body encoding.
+- `HttpClient.filterStatusOk` / `HttpClientResponse.filterStatusOk` before decoding when non-2xx responses are failures.
+- `HttpClientResponse.schemaBodyJson(...)` for body-only decoding, `schemaJson(...)` for status/headers/body decoding, and `schemaNoBody(...)` for status/headers decoding.
+- `HttpClient.retryTransient(...)` for common transient HTTP failures.
+- `HttpClient.withRateLimiter(...)` for proactive pacing and learning from rate-limit headers. It requires a `RateLimiter` plus initial window, limit, and key options; it adds `RateLimiterError` to the error channel and retries `429` responses by default.
+
+## Retry And Rate Limits
+
+Use `HttpClient.retryTransient(...)` for common transient HTTP failures:
+
+- transport errors
+- timeouts
+- `408`
+- `429`
+- `500`
+- `502`
+- `503`
+- `504`
+
+Use `HttpClient.withRateLimiter(...)` when the client should proactively pace requests and learn from rate-limit / `Retry-After` headers.
+
+Use operation-level `Effect.retry(...)` when retry depends on domain-specific typed errors, provider payloads, or idempotency rules. Read `SCHEDULING.md` for custom schedules and `retryAfterMs` typed-provider patterns.
+
+## Raw Fetch Exception
+
+Use raw `fetch` deliberately when implementing a platform transport, adapting an API that cannot use Effect HttpClient, or targeting a runtime/library boundary where the unstable Effect HTTP modules are not an appropriate dependency.
+
+If a temporary raw `fetch` boundary is unavoidable, keep it inside an adapter service and still use Effect boundary discipline.
+
+```ts
+const request = Effect.fn("Provider.request")(function* (input: RequestInput) {
+  const response = yield* Effect.tryPromise({
+    try: (signal) => fetch(input.url, { signal, headers: input.headers }),
+    catch: (cause) => new ProviderError({ operation: "Provider.request", cause }),
+  })
+
+  if (!response.ok) {
+    return yield* Effect.fail(new ProviderRejected({
+      operation: "Provider.request",
+      status: response.status,
+    }))
+  }
+
+  const json = yield* Effect.tryPromise({
+    try: () => response.json(),
+    catch: (cause) => new ProviderError({ operation: "Provider.decodeJson", cause }),
+  })
+
+  return yield* Schema.decodeUnknownEffect(ResponseSchema)(json).pipe(
+    Effect.mapError((cause) =>
+      new ProviderError({ operation: "Provider.decodeResponse", cause }),
+    ),
+  )
+})
+```
+
+Guidance:
+
+- Prefer replacing this with Effect HttpClient before adding more behavior.
+- Wire `AbortSignal` from `Effect.tryPromise` into `fetch` when raw fetch is unavoidable.
+- Classify HTTP status before decoding successful payloads.
+- Decode unknown response bodies with Schema at the boundary.
+- Preserve provider evidence needed for diagnosis, but redact secrets and private payloads.
+- Apply retry only for idempotent operations.

--- a/examples/effect/references/SCHEDULING.md
+++ b/examples/effect/references/SCHEDULING.md
@@ -1,0 +1,135 @@
+# Scheduling And Retry
+
+Use this when writing retries, repeats, polling workers, backoff, jitter, rate-limit-aware policies, timeouts, or pass loops.
+
+Use `Schedule` for retry, polling, pacing, and repeated background work instead of hand-rolled `while (true)` loops with sleeps.
+
+## Core Rules
+
+- `Effect.retry(...)` retries typed failures; defects and interruptions are not retried.
+- `Effect.repeat(...)` repeats successful effects; failures stop repetition unless the pass handles them first.
+- The source effect runs once before the schedule is stepped.
+- `Schedule.recurs(3)` means three retries/repetitions after the initial run.
+- `Schedule.spaced(...)` waits after work completes.
+- `Schedule.fixed(...)` aligns executions to a cadence.
+- Use `Schedule.exponential(...)` or `Schedule.fibonacci(...)` for backoff.
+- Add `Schedule.jittered` to avoid synchronized retry storms.
+- Use `Schedule.recurs(...)` for a counter schedule or `Schedule.upTo({ times })` to bound a delay schedule.
+- Use `Schedule.tapInput(...)` to log retry inputs.
+- Use `Schedule.tap(...)` when full schedule metadata matters.
+- Use `Effect.retryOrElse(...)` when exhausted retries need a fallback/reporting effect.
+- Retry only at the narrowest boundary with proven idempotency.
+- Exhausted failures should remain visible unless the boundary has a truthful fallback.
+
+## Polling Workers
+
+Prefer typed pass failures over cause recovery.
+
+```ts
+const pass = runPass().pipe(
+  Effect.tapError((error) =>
+    Effect.logError("Worker.pass_failed", error),
+  ),
+  Effect.ignore,
+)
+
+const run = pass.pipe(
+  Effect.repeat(Schedule.spaced("1 second")),
+)
+```
+
+This shape says expected operational pass failures are logged and the worker continues. Defects still defect and can reach supervision.
+
+Use cause-level recovery only at supervision boundaries where the policy is truly "report non-interrupt failure and continue".
+
+```ts
+const logNonInterruptCauseAndContinue = (message: string) =>
+  Effect.catchCauseIf(
+    (cause) => !Cause.hasInterrupts(cause),
+    (cause) => Effect.logError(message, cause),
+  )
+```
+
+Do not catch causes just to make failures disappear. If only expected typed failures should be recoverable, use `Effect.catchIf(...)`, `Effect.catchFilter(...)`, `Effect.catchTag(...)`, or `Effect.retry(...)` on those typed errors instead.
+
+## Per-Item Failure Isolation
+
+For batch workers, catch expected item-level typed failures around each item so one bad item does not stall the batch.
+
+```ts
+yield* Effect.forEach(
+  items,
+  (item) =>
+    processItem(item).pipe(
+      Effect.tapError((error) =>
+        Effect.logError("Worker.item_failed", error).pipe(
+          Effect.annotateLogs({ itemId: item.id }),
+        ),
+      ),
+      Effect.ignore,
+    ),
+  { discard: true, concurrency: 5 },
+)
+```
+
+Only do this when retrying the item later is truthful or skipping the item is the product policy.
+
+## Reusable Retry Policy
+
+```ts
+const projectionRetrySchedule: Schedule.Schedule<unknown, ProjectionError> =
+  Schedule.exponential("100 millis").pipe(
+    Schedule.jittered,
+    Schedule.upTo({ times: 5 }),
+  )
+
+const reconcileWithRetry = (target: Target) =>
+  reconcile(target).pipe(
+    Effect.retryOrElse(
+      projectionRetrySchedule.pipe(
+        Schedule.tapInput((error) =>
+          Effect.logWarning("Agent.Projection.reconcile.retrying").pipe(
+            Effect.annotateLogs({ operation: error.operation }),
+          ),
+        ),
+      ),
+      (error) => Effect.logError("Agent.Projection.reconcile.stopped", error),
+    ),
+  )
+```
+
+Use this when the operation is idempotent and retry state is useful for logs or metrics.
+
+## Rate-Limit-Aware Typed Retry
+
+For provider errors that carry `retryAfterMs`, let the schedule use the larger of the backoff delay and the provider delay.
+
+```ts
+type RateLimited = {
+  readonly retryAfterMs?: number | undefined
+}
+
+const providerRetrySchedule: Schedule.Schedule<RateLimited, RateLimited> =
+  Schedule.exponential("200 millis").pipe(
+    Schedule.jittered,
+    Schedule.upTo({ times: 5 }),
+    Schedule.passthrough,
+    Schedule.modifyDelay(({ input, duration }) =>
+      Effect.succeed(
+        input.retryAfterMs === undefined
+          ? duration
+          : Duration.max(duration, Duration.millis(input.retryAfterMs)),
+      ),
+    ),
+  )
+```
+
+Use this for operation-level retries over typed provider errors. For Effect HttpClient-level 429 handling and proactive pacing, read `HTTP_CLIENTS.md`.
+
+## Timeouts And Delays
+
+- Use `Effect.timeout(...)` when the operation has a real deadline.
+- Use `Effect.delay(...)` when one operation should start later.
+- Use `Effect.sleep(...)` inside production workflows only when sleeping itself is the domain behavior.
+- Avoid manual sleep loops; use `Effect.repeat(...)` with `Schedule` for recurring work.
+- In tests, use `TestClock` rather than real time. Read `TESTING.md`.

--- a/examples/effect/references/SCHEMA.md
+++ b/examples/effect/references/SCHEMA.md
@@ -1,0 +1,130 @@
+# Schema And Data Modeling
+
+Use this when touching data models, DTOs, row schemas, wire contracts, brands, variants, optional fields, or decoders.
+
+## Records
+
+Default to `Schema.Struct(...)` plus a same-name `interface`.
+
+```ts
+export const User = Schema.Struct({
+  id: UserId,
+  name: Schema.NonEmptyString,
+  email: Schema.optionalKey(Schema.String),
+})
+
+export interface User extends Schema.Schema.Type<typeof User> {}
+```
+
+Guidance:
+
+- Add `.annotate({ identifier: "User" })` only when tooling consumes it: HTTP API, RPC, OpenAPI/JSON Schema, docs, diagnostics, or codegen.
+- Use `schema.make(...)` when construction is trusted.
+- Use `schema.makeEffect(...)` when construction failure should stay in the Effect error channel.
+- Decode unknown input at boundaries with `Schema.decodeUnknownEffect(...)` by default.
+- Use `Schema.decodeUnknownSync(...)` only in scripts, tests, or startup paths where throwing is acceptable.
+- Use `Schema.decodeUnknownOption(...)` only when mismatch details are intentionally discarded.
+- Use `Schema.decodeUnknownResult(...)` for pure code that wants explicit success/failure without Effect.
+
+## Field And Contract Reuse
+
+Reuse fields directly when contracts are semantically related.
+
+```ts
+export const CreateUserInput = Schema.Struct({
+  name: User.fields.name,
+  email: User.fields.email,
+})
+
+export const StoredUser = User.pipe(
+  Schema.fieldsAssign({
+    createdAt: Schema.DateTimeUtcFromString,
+  }),
+)
+```
+
+Guidance:
+
+- Use `.fields`, `Schema.fieldsAssign(...)`, and `.mapFields(...)` when contracts are genuinely related.
+- Use `Schema.encodeKeys(...)` when decoded TypeScript names differ from encoded wire/storage keys and naming is the only difference.
+- Keep explicit mapping when behavior, joins, validation, or domain translation is involved.
+- Use `Schema.extendTo(...)` sparingly for decoded-only derived fields.
+- Use field reuse to build small related contracts, not one oversized inheritance-by-schema object.
+
+## Optionality And Defaults
+
+- Use `Schema.optionalKey(...)` for absent JSON/storage keys.
+- Use `Schema.optional(...)` only when explicit `undefined` is part of the contract.
+- Use `Schema.NullOr`, `Schema.UndefinedOr`, or `Schema.NullishOr` only when nullish values are truly part of the encoded contract.
+- Keep normalized defaulted values as required fields and apply defaults in constructors/decoding.
+- Do not make domain values optional merely for construction convenience.
+
+## Nominal Values
+
+- Use constrained branded schemas for scalar IDs and value objects.
+- Use normal schema constraints before `Schema.brand(...)` for most code.
+- Reach for `Schema.fromBrand(...)` only when the project already models brands with `Brand` constructors or wants the check packaged with the brand constructor.
+
+## Variants
+
+```ts
+type Step = Data.TaggedEnum<{
+  Continue: { readonly cursor: number }
+  Finished: { readonly count: number }
+}>
+
+export const Step = Data.taggedEnum<Step>()
+
+const next = Step.Continue({ cursor: 10 })
+const label = Step.$match(next, {
+  Continue: ({ cursor }) => `continue at ${cursor}`,
+  Finished: ({ count }) => `finished ${count}`,
+})
+```
+
+```ts
+export const Event = Schema.TaggedUnion({
+  Started: { runId: RunId },
+  Finished: { runId: RunId, result: Schema.Json },
+})
+
+export type Event = typeof Event.Type
+
+const event = Event.cases.Started.make({ runId })
+const label = Event.match(event, {
+  Started: ({ runId }) => `started ${runId}`,
+  Finished: ({ runId }) => `finished ${runId}`,
+})
+```
+
+Guidance:
+
+- Use `Data.TaggedEnum` for internal control-flow algebras; it provides constructors, `$is`, and exhaustive `$match`. Do not add a Schema solely to obtain these utilities.
+- Use `Schema.TaggedStruct` for the ordinary Effect-owned `_tag` variant.
+- Use `Schema.TaggedUnion` when the union needs decoding, encoding, persistence, wire validation, JSON Schema derivation, or schema composition.
+- Prefer a principled split over forcing one representation everywhere: Data internally, Schema at boundaries.
+- Use `Schema.tag(...)` when an external contract has a custom discriminator field such as `type` or `kind`; combine those structs with `Schema.toTaggedUnion("type")` when union helpers are needed.
+- If the encoded contract omits the discriminant, use `Schema.tagDefaultOmit(...)` deliberately.
+- Avoid `Schema.Class` and `Schema.TaggedClass` for new data models.
+
+## Errors
+
+`Schema.TaggedErrorClass` is the explicit class exception for typed Effect errors.
+
+```ts
+export class PersistenceError extends Schema.TaggedErrorClass<PersistenceError>()(
+  "UserRepo.PersistenceError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+```
+
+Guidance:
+
+- Map infrastructure failures into domain-specific tagged errors at service boundaries.
+- Include operation labels when they help diagnose adapter, persistence, provider, or transport failures.
+- Use schema unions for public API or transport error surfaces.
+- Use `Schema.Defect()` for defect-like payloads.
+- Preserve interruption when catching broad causes at ingress, worker, or stream boundaries.

--- a/examples/effect/references/SERVICES_LAYERS.md
+++ b/examples/effect/references/SERVICES_LAYERS.md
@@ -1,0 +1,168 @@
+# Services, Layers, And Modules
+
+Use this when defining service tags, module surfaces, layer implementations, runtime wiring, typed errors, or `Effect.fn` operation boundaries.
+
+## Module Surface
+
+One opinionated application-module style uses file-local role names and one canonical ES module namespace projection. Follow the existing codebase's module style when it has one; this convention is not required by Effect.
+
+```ts
+export interface Interface {
+  readonly get: (id: UserId) => Effect.Effect<User, NotFound | PersistenceError>
+}
+
+export class Service extends Context.Service<Service, Interface>()(
+  "@app/UserRepo",
+) {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const get = Effect.fn("UserRepo.get")(function* (id: UserId) {
+      // ...
+    })
+
+    return Service.of({ get })
+  }),
+)
+
+export class NotFound extends Schema.TaggedErrorClass<NotFound>()(
+  "UserRepo.NotFound",
+  { id: UserId },
+) {}
+
+export * as UserRepo from "./user-repo.js"
+```
+
+Consumers use the module namespace.
+
+```ts
+import { UserRepo } from "./user-repo.js"
+
+const program = Effect.gen(function* () {
+  const repo = yield* UserRepo.Service
+  return yield* repo.get(id)
+})
+```
+
+The self-export is deliberate. It lets the file remain the module while giving every consumer the same domain-first name, without a TypeScript `namespace`, wrapper object, or repeated consumer-side aliases.
+
+```ts
+// Sibling module: import the owning leaf directly.
+import { UserRepo } from "./user-repo.js"
+
+// Folder or package barrel: relay the identity established by the leaf.
+export { UserRepo } from "./user-repo.js"
+```
+
+Guidance:
+
+- Do not name the tag class `UserRepo` inside `user-repo.ts`; the module namespace is the domain name.
+- In this module style, single-file modules self-export their canonical namespace at the bottom: `export * as UserRepo from "./user-repo.js"`.
+- Sibling modules import that namespace from the owning leaf; they do not import through their own aggregate barrel.
+- Folder and package barrels relay established leaf identities with `export { UserRepo } from "./user-repo.js"`.
+- The resulting `UserRepo.UserRepo === UserRepo` self-reference is unusual. Use this pattern only where the runtime and toolchain support it; otherwise use named exports or a separate barrel.
+- Export only intentional surface; keep local schemas, row codecs, helpers, and implementation details unexported.
+- Do not introduce TypeScript `namespace` declarations for organization.
+- Use a named service class such as `class UserRepo extends Context.Service...` when an external library or existing codebase does not use module namespace style.
+
+## Layer Constructors
+
+Choose the layer constructor that matches the thing produced.
+
+```ts
+Layer.succeed(Service, impl)       // already-built service
+Layer.sync(Service, () => impl)    // lazy synchronous service
+Layer.effect(Service, makeEffect)  // effectful service acquisition
+```
+
+Guidance:
+
+- Default real implementations to `Layer.effect(Service, Effect.gen(...))`.
+- Use `Layer.effectContext(...)` when one acquisition intentionally supplies multiple services, especially first-class test stubs or one client backing several service tags.
+- Use `Layer.unwrap(...)` when config or runtime discovery chooses/builds the layer.
+- Use `Layer.fresh(...)` or `Effect.provide(layer, { local: true })` only when a test or operation needs isolated acquisition.
+- Use `Context.Reference` rarely, only for ambient/defaultable runtime references where a safe default is real.
+
+## Long-Lived Work
+
+A layer that starts a stream, listener, worker, subscription, or forever loop must fork that work into the layer scope. Layer acquisition must complete.
+
+```ts
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const events = yield* Events.Service
+
+    yield* events.stream.pipe(
+      Stream.runForEach(handleEvent),
+      Effect.forkScoped,
+    )
+  }),
+)
+```
+
+Guidance:
+
+- Use `Effect.forkScoped`, `FiberSet`, or `FiberMap` for scoped background work.
+- Do not run forever work inline during layer acquisition.
+- Do not expose public `start` methods unless the domain explicitly needs manual lifecycle control.
+
+## Runtime Wiring
+
+- Use `Layer.provide(...)` to hide an implementation dependency.
+- Use `Layer.provideMerge(...)` only when the dependency should remain exposed for downstream consumers.
+- Use `Layer.mergeAll(...)` for independent exposed layers.
+- Prefer flat, topologically sorted runtime layer values with named subgraphs.
+- Avoid using `provideMerge` as a blind make-it-compile tool.
+- Avoid hiding important authority or lifecycle dependencies behind broad invisible provisioning.
+
+## Effect.fn
+
+Use extra `Effect.fn(...)` arguments for wrappers that apply to the whole function call. Each transform receives `(effect, ...originalArgs)`.
+
+```ts
+const readAttachment = Effect.fn("Attachment.read")(
+  function* (ref: AttachmentRef) {
+    return yield* api.read(ref)
+  },
+  (effect, ref) =>
+    effect.pipe(
+      attachmentError("Attachment.read", { attachmentId: ref.id }),
+    ),
+)
+```
+
+Good whole-function transforms:
+
+- error classification
+- localized recovery
+- logging annotations
+- spans
+- retry
+- timeout
+- ensuring cleanup
+- small local provisioning
+- result mapping
+
+Guidance:
+
+- Keep the generator body focused on the core workflow.
+- Use transforms when the wrapper needs original arguments.
+- Do not build long clever pipelines; one or two transforms is usually enough.
+- Do not use this for local branch-level handling inside the workflow.
+
+## Operation Error Helpers
+
+For boundary errors with operation labels, prefer a shared curried `mapError` helper over hand-writing wrappers in every module.
+
+```ts
+const persistenceError = operationError(PersistenceError.make)
+
+const row = yield* query.pipe(
+  persistenceError("UserRepository.findById"),
+)
+```
+
+Name the local helper after the error it produces, such as `persistenceError`, `projectionError`, or `processingError`. Use `Effect.fn(...)` and spans for observability in addition to payload labels, not instead of them.

--- a/examples/effect/references/STREAMS.md
+++ b/examples/effect/references/STREAMS.md
@@ -1,0 +1,135 @@
+# Streams
+
+Use this when working with `Stream`, event sources, async iterables, queue/pubsub-backed streams, pagination, backpressure, throttling, debouncing, or long-lived stream consumers.
+
+## Mental Model
+
+`Stream<A, E, R>` is an effectful source that can emit many `A` values over time, fail with `E`, and require services `R`. Streams are pull-based and backpressured; consumption controls demand.
+
+Use streams for sources that are naturally many-valued and time-ordered:
+
+- gateway events
+- provider callbacks adapted through queues
+- subscription/event logs
+- paginated APIs
+- file/stdin/platform streams
+- scheduled ticks when values matter
+- pipelines with filtering, mapping, buffering, throttling, or bounded concurrent processing
+
+Do not use streams just to loop forever. For one repeated effect with no emitted values, use `Effect.repeat(...)` with `Schedule`; read `SCHEDULING.md`.
+
+## Source Chooser
+
+- In-memory values: `Stream.make(...)` or `Stream.fromIterable(...)`.
+- Test fixtures: `Stream.fromIterable(...)`, often with `Stream.concat(Stream.never)` for an open subscription.
+- Queue-backed callback boundary: `Queue` plus `Stream.fromQueue(...)`.
+- Broadcast events: `PubSub` plus `Stream.fromPubSub(...)`.
+- Latest-value state plus updates: `SubscriptionRef`.
+- Schedule-generated ticks/values: `Stream.fromSchedule(...)`.
+- Paginated pull APIs: `Stream.paginate(...)`; its step function is already effectful, returning `Effect<[chunk, Option<nextState>]>`.
+- Async iterable/platform source: `Stream.fromAsyncIterable(...)` when no native Effect source exists.
+- Effect that produces a stream after reading services/config: `Stream.unwrap(...)`.
+
+## Transformation Chooser
+
+- Pure transformation: `Stream.map(...)`.
+- Effectful transformation: `Stream.mapEffect(...)`.
+- Bounded concurrent effectful transformation: `Stream.mapEffect(fn, { concurrency })`.
+- Drop ordering when order is irrelevant and latency matters: `Stream.mapEffect(fn, { concurrency, unordered: true })`.
+- One input to zero/many outputs: `Stream.flatMap(...)`.
+- Multiple inner streams concurrently: `Stream.flatMap(fn, { concurrency })`.
+- Keep only matching values: `Stream.filter(...)` / `Stream.filterEffect(...)`.
+- Stateful transformation: `Stream.mapAccum(...)` / `Stream.mapAccumEffect(...)`.
+- Paginated pull-to-pages: prefer `Stream.paginate(...)` over hand-rolled loops. There is no separate `Stream.paginateEffect`.
+
+## Consumption Chooser
+
+- Side-effecting consumer: `Stream.runForEach(...)`.
+- Ignore elements but run the stream: `Stream.runDrain`.
+- Tests/small finite streams: `Stream.runCollect`.
+- First N values in tests: `Stream.take(n)` plus `Stream.runCollect`.
+- Fold into a value: `Stream.runFold(...)`.
+- Long-lived consumer in a layer: `stream.pipe(Stream.runForEach(...), Effect.forkScoped)`.
+
+Avoid `Stream.runCollect` on unbounded or production event streams.
+
+## Long-Lived Consumers
+
+Own long-lived stream consumers in layers and fork them into the layer scope.
+
+```ts
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const gateway = yield* Gateway.Service
+
+    yield* gateway.events.pipe(
+      Stream.filter(isMessageEvent),
+      Stream.runForEach(handleEvent),
+      Effect.forkScoped,
+    )
+  }),
+)
+```
+
+Guidance:
+
+- Let the layer own the stream lifetime.
+- Use `Effect.forkScoped` for the ordinary case.
+- If methods need to fork work into the layer lifetime, capture `Scope.Scope` during layer acquisition and use `Effect.forkIn(scope)` internally. Do not expose the scope as public service API.
+- Preserve stream failures unless the owning boundary has a truthful recovery policy.
+
+## Queues, PubSub, And SubscriptionRef
+
+- Use `Queue` when each event/item should be consumed by one consumer or worker.
+- Use `PubSub` when every subscriber should see every event.
+- Use `SubscriptionRef` when consumers need the current value and a stream of changes.
+- Expose a `Stream` from service interfaces when callers should consume events, not push into the queue.
+- Keep producer queues/private refs inside the implementation or test service.
+
+Good service shape:
+
+```ts
+export interface Interface {
+  readonly events: Stream.Stream<ProviderEvent, ProviderError>
+  readonly status: Stream.Stream<ProviderStatus>
+}
+```
+
+Implementation can use private `Queue` / `SubscriptionRef`; consumers see streams.
+
+## Backpressure And Buffers
+
+Prefer natural stream backpressure first.
+
+Use `Stream.buffer(...)` only when producer and consumer should decouple.
+
+- `strategy: "suspend"`: apply backpressure when full.
+- `strategy: "dropping"`: drop new values when full.
+- `strategy: "sliding"`: keep the latest values by dropping old ones.
+- `capacity: "unbounded"`: rare; use only when growth is bounded elsewhere.
+
+Use `Stream.debounce(...)` for quiet-period behavior and `Stream.throttle(...)` / `Stream.throttleEffect(...)` for rate-shaped streams.
+
+## Error Handling
+
+- Prefer typed stream errors over defects.
+- Use `Stream.mapError(...)` to translate errors at boundaries.
+- Use `Stream.catchIf(...)`, `Stream.catchTag(...)`, or `Stream.catchFilter(...)` for typed recovery.
+- Use `Stream.catchCause(...)` only at explicit supervision boundaries.
+- Do not hide stream defects by default; let them reach the owning layer/runtime unless the stream is explicitly best-effort.
+
+## Keyed Concurrency
+
+For streams of work keyed by session/channel/id, prefer a named helper over ad hoc maps of fibers.
+
+If the codebase already has a keyed-run helper (for example a `runForEachKeyed` that runs different keys concurrently while serializing each key and coalescing pending values into one latest-value rerun), use it. Otherwise build one named helper with `FiberMap` rather than scattering fiber bookkeeping through consumers.
+
+Use this for projection/reconciliation streams where each key needs ordered processing but different keys can run in parallel.
+
+## Tests
+
+- Use `Stream.fromIterable(...)` for finite fixtures.
+- Use `Stream.empty` for no events.
+- Use `Stream.fromQueue(...)` with a test-owned `Queue` when the test needs to drive events interactively.
+- Use `Stream.take(n)` plus `Stream.runCollect` for finite assertions.
+- Avoid real sleeps; coordinate with `Deferred`, `Queue`, `Latch`, and `TestClock`.

--- a/examples/effect/references/TESTING.md
+++ b/examples/effect/references/TESTING.md
@@ -1,0 +1,118 @@
+# Testing
+
+Use this when writing Effect tests, tests involving time, retry, schedules, concurrency, workers, services, fakes, or config.
+
+## Defaults
+
+- Use `it.effect` by default.
+- Use `it.live` only when real time or live runtime services are the behavior under test.
+- Use test layers and `ConfigProvider` rather than global mutation.
+- Use `TestClock.setTime` / `TestClock.adjust` for sleeps, schedules, retries, leases, and timeouts.
+- Fork sleeping effects before advancing `TestClock`.
+- Avoid arbitrary `Effect.sleep(...)` in tests; it usually makes tests slow and flaky.
+- Assert typed failures, rollback, interruption, finalization, retry bounds, idempotency, concurrency laws, and malformed persistence where relevant.
+
+```ts
+it.effect("finds a user", () =>
+  Effect.gen(function* () {
+    const users = yield* UserRepo.Service
+    const result = yield* users.find(UserId.make("u1"))
+    expect(Option.isSome(result)).toBe(true)
+  }).pipe(Effect.provide(UserRepo.testLayer)),
+)
+```
+
+## Synchronization Instead Of Sleeps
+
+- Use `Deferred` for one-shot readiness/completion signals.
+- Use `Queue` for handing test-controlled work or observed events across fibers.
+- Use `Latch` for reusable open/close coordination gates.
+- Use `Ref` for shared test observation state.
+- Use explicit test hooks when the production boundary can expose a deterministic synchronization point.
+
+```ts
+it.effect("publishes exactly once", () =>
+  Effect.gen(function* () {
+    const published = yield* Queue.unbounded<Message>()
+    const ready = yield* Deferred.make<void>()
+
+    const runWorker = makeWorker({
+      onReady: () => Deferred.succeed(ready, undefined),
+      onPublish: (message) => Queue.offer(published, message),
+    })
+
+    yield* runWorker.pipe(
+      Effect.forkScoped,
+    )
+
+    yield* Deferred.await(ready)
+    const message = yield* Queue.take(published)
+
+    expect(message).toEqual(expectedMessage)
+  }),
+)
+```
+
+## First-Class App Test Stubs
+
+Use `TestInterface extends Interface`, `TestService`, and `testLayer` for reusable/stateful fakes.
+
+```ts
+export interface Interface {
+  readonly send: (message: Message) => Effect.Effect<void, SendError>
+}
+
+export class Service extends Context.Service<Service, Interface>()(
+  "@app/Notifier",
+) {}
+
+export interface TestInterface extends Interface {
+  readonly sentMessages: () => Effect.Effect<ReadonlyArray<Message>>
+  readonly failNextSend: (error: SendError) => Effect.Effect<void>
+}
+
+export class TestService extends Context.Service<TestService, TestInterface>()(
+  "@app/Notifier/Test",
+) {}
+
+export const testLayer = Layer.effectContext(
+  Effect.gen(function* () {
+    const sent = yield* Ref.make<ReadonlyArray<Message>>([])
+    const nextFailure = yield* Ref.make<Option.Option<SendError>>(Option.none())
+
+    const service = TestService.of({
+      send: Effect.fn("Notifier.Test.send")(function* (message) {
+        const failure = yield* Ref.getAndSet(nextFailure, Option.none())
+        if (Option.isSome(failure)) return yield* Effect.fail(failure.value)
+        yield* Ref.update(sent, (messages) => [...messages, message])
+      }),
+      sentMessages: Effect.fn("Notifier.Test.sentMessages")(function* () {
+        return yield* Ref.get(sent)
+      }),
+      failNextSend: Effect.fn("Notifier.Test.failNextSend")(function* (error) {
+        yield* Ref.set(nextFailure, Option.some(error))
+      }),
+    })
+
+    return Context.empty().pipe(
+      Context.add(Service, service),
+      Context.add(TestService, service),
+    )
+  }),
+)
+```
+
+Guidance:
+
+- The same object should back both the real `Service` tag and `TestService` tag.
+- Production code depends only on the real service tag.
+- Tests use `TestService` for control and inspection.
+- Use function-valued service members, including zero-argument operations, so `Effect.fn` fits naturally.
+- Use `Layer.succeed` for complete dead-simple static test implementations.
+- Use `Layer.mock` only for tiny local partial mocks where omitted members should fail loudly if used.
+
+## Config In Tests
+
+Use `ConfigProvider.layer(ConfigProvider.fromUnknown(...))` when the test should exercise Config decoding.
+
+Use `Layer.succeed(AppConfiguration.Service, config)` when the app wraps decoded config in its own service and the test does not need to exercise env decoding.

--- a/examples/effect/spec.md
+++ b/examples/effect/spec.md
@@ -1,0 +1,106 @@
+# Effect
+
+## Intent
+
+Guide agents that build, review, debug, or refactor production TypeScript applications using current Effect APIs. The skill keeps architecture explicit, grounds API advice in the target project, models data and failures with Schema, and chooses Effect runtime primitives from the behavior and lifecycle the code requires.
+
+The skill exists to prevent remembered APIs, unchecked casts, hidden dependencies, ad hoc concurrency, and recovery behavior that changes the truth of an external boundary.
+
+## Triggers
+
+- **SHOULD** apply to TypeScript work using Effect workflows, schemas, services, layers, configuration, schedules, caches, streams, HTTP clients, or Effect-aware tests
+- **SHOULD** apply when the user asks how to model an application boundary or choose an Effect primitive
+- **SHOULD NOT** apply to TypeScript work that does not use Effect or request an Effect-based design
+- **SHOULD NOT** replace an explicitly required older Effect API surface with a newer one
+
+## Behaviors
+
+### Behavior: Ground Advice in the Project
+
+The agent SHALL inspect repository instructions, the installed or pinned Effect version, available package source, and local conventions before choosing uncertain APIs.
+
+#### Scenario: Replace a Retry Loop
+
+- **WHEN** a project pins Effect and the user asks to replace a hand-written retry loop with a Schedule
+- **THEN** the agent verifies the installed Schedule API and uses a signature supported by that project instead of relying on memory
+
+### Behavior: Load Guidance by Concern
+
+The agent SHALL identify every Effect concern in the task and read only the matching reference files, including multiple references when a change crosses concerns.
+
+#### Scenario: Service Owns a Stream Consumer
+
+- **WHEN** the user asks for a service layer that owns a long-lived event consumer
+- **THEN** the agent applies both service/layer guidance and stream lifetime guidance
+
+### Behavior: Model Data and Failures With Schema
+
+The agent SHALL use Effect Schema for application records, untrusted boundary decoding, brands, tagged variants, unions, and expected typed failures.
+
+#### Scenario: Decode an Untrusted Event
+
+- **WHEN** an HTTP adapter receives an unknown tagged payload
+- **THEN** the agent defines a Schema union, decodes the unknown value effectfully, and maps parse failure into a typed Effect error without unchecked casts
+
+### Behavior: Build Explicit Services and Layers
+
+The agent SHALL keep business rules in named Effect workflows and services, represent dependencies explicitly, construct implementations in layers, and keep transport handlers thin.
+
+#### Scenario: Extract Logic From a Handler
+
+- **WHEN** an HTTP handler reads configuration, calls a provider, writes persistence, and maps domain failures directly
+- **THEN** the agent moves the workflow behind an explicit service and layer while leaving the handler responsible for transport concerns
+
+### Behavior: Choose Native Runtime Primitives
+
+The agent SHALL choose Config, Schedule, Cache or memoization, request batching, Queue, PubSub, SubscriptionRef, and Stream according to the operation's semantics and lifecycle.
+
+#### Scenario: Replace a TTL Map
+
+- **WHEN** code uses a Map with timestamps and in-flight promises for provider lookups
+- **THEN** the agent uses an Effect cache with bounded ownership and exit-aware TTL, without adding batching unless the backend has a real batch endpoint
+
+### Behavior: Keep External Boundaries Truthful
+
+The agent SHALL wrap external integrations in named Effect boundaries, decode untrusted responses, preserve typed transport, status, and decode failures, and add retries or fallbacks only when the operation and recovery policy justify them.
+
+#### Scenario: Retry an Idempotent Provider Request
+
+- **WHEN** an idempotent GET can return rate limits, transport failures, non-success status, or malformed JSON
+- **THEN** the agent separates failure types, retries only bounded transient failures, and keeps exhausted failures visible
+
+### Behavior: Test Effect Code Deterministically
+
+The agent SHALL use Effect-aware tests, explicit layers, virtual time, and deterministic synchronization instead of global mutation or arbitrary real sleeps.
+
+#### Scenario: Test a Delayed Worker
+
+- **WHEN** a test must prove that a forked worker retries after a delay and publishes once
+- **THEN** the agent advances TestClock and coordinates the fiber with Deferred, Queue, Latch, Ref, or another deterministic primitive
+
+### Behavior: Preserve Types and Visible Dependencies
+
+The agent SHALL solve type and dependency errors at their source without unchecked casts, non-null assertions, broad cause recovery, hidden authority defaults, or blind layer merging.
+
+#### Scenario: Missing Service Requirement
+
+- **WHEN** a workflow fails to typecheck because a persistence service is missing
+- **THEN** the agent wires the service through explicit Effect and Layer composition instead of weakening types or hiding the requirement
+
+## Constraints
+
+### Constraint: No Invented APIs
+
+The agent MUST NOT present an uncertain remembered API as valid without checking the pinned package or current source.
+
+### Constraint: No Validation Bypasses
+
+The agent MUST NOT use `as any`, unchecked casts, non-null assertions, or throwing construction at untrusted boundaries to silence type or decoding errors.
+
+### Constraint: No Dishonest Recovery
+
+The agent MUST NOT retry non-idempotent operations, swallow exhausted failures, catch defects as ordinary typed errors, or invent fallback values without a real recovery policy.
+
+### Constraint: No Ad Hoc Replacements
+
+The agent MUST NOT replace fitting Effect primitives with manual sleep synchronization, hand-rolled caches, blind layer merging, or direct `process.env` reads in application workflows.

--- a/examples/garfield/LICENSE
+++ b/examples/garfield/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/garfield/README.md
+++ b/examples/garfield/README.md
@@ -1,0 +1,13 @@
+# Garfield Example
+
+This directory contains two versions of Garfield:
+
+- `original/` is an exact snapshot of `dcramer/agents/skills/garfield` at the commit recorded in `UPSTREAM.md`.
+- The files at this directory root are a Skillet-authored version with a behavior spec, compact agent instructions, references, and eval cases.
+
+Validate the generated example:
+
+```bash
+skillet validate examples/garfield
+skillet eval examples/garfield --dry
+```

--- a/examples/garfield/SKILL.md
+++ b/examples/garfield/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: garfield
+description: Coordinates subagent review, fixes, and verification during implementation; use when the user explicitly asks for Garfield on an active code slice, but not for standalone review, brainstorming, non-code work, or PR CI iteration.
+spec_hash: f50812cb5e67
+disable-model-invocation: true
+---
+
+# Garfield
+
+Use Garfield only when the user explicitly requests it during implementation. Review the current slice, preserve the user's intent, fix material current-diff problems, and stop when the slice is ready.
+
+## 1. Capture the Intent
+
+Before delegating review, record:
+
+- requested behavior and intended changes
+- compatibility expectations and non-goals
+- diff/base and touched files
+- repository instructions and relevant specs
+- tests, generated artifacts, dependencies, and validation already run
+
+Use this snapshot to judge every finding. Do not let a reviewer redefine the task.
+
+## 2. Build the Effective Policy Set
+
+Discover applicable repository policies under `policies/**/*.md`, excluding policy indexes and templates. Compare them with Garfield's bundled policies by intent and scope:
+
+- repository-wide policy for the same concern: use it and omit the bundled policy
+- narrower or adjacent policy: keep both
+- unrelated policy: ignore it
+
+Bundled policies:
+
+- Read `references/code-comments.md` when comments or docstrings changed.
+- Read `references/implementation-minimalism.md` when the slice adds guards, fallbacks, adapters, configuration, or defensive tests.
+- Read `references/interface-design.md` when public/module boundaries, lifecycle, ownership, or naming changed.
+- Read `references/test-quality.md` when tests, fixtures, or test obligations changed.
+
+## 3. Select Review Tasks
+
+Always review:
+
+- behavior and spec alignment
+- repository instructions
+- validation coverage
+
+Consider specs/docs, dead code, delayering, type boundaries, generated/dependency artifacts, comments, minimalism, interface design, test quality, and effective repository policies. Mark every candidate `applicable` or `skipped` from concrete diff evidence.
+
+## 4. Delegate Reviews
+
+Use one no-edit subagent per applicable task or policy. Give each reviewer only the slice context and policy it needs. Keep at most three Garfield subagents open at once:
+
+1. Start up to three reviewers.
+2. Collect and close completed reviewers.
+3. Start the next reviewers.
+4. Drain review agents before independent verification.
+
+If subagents or required capacity are unavailable, stop and report that Garfield cannot run.
+
+Require findings in this form:
+
+```text
+[severity][evidence:<label[,label]> <locator>] path:line - concern. impact: <impact>. fix: <smallest change>.
+```
+
+## 5. Triage and Fix
+
+Accept a finding only when the current diff introduced or worsened it, made evidence stale, or omitted a required artifact.
+
+- Fix blocker and high findings when the smallest fix preserves intent.
+- Fix medium findings only when they are current-diff-caused and local.
+- Reject vague, preference-only, or evidence-free findings.
+- Defer unrelated hardening, broad cleanup, and out-of-intent behavior changes.
+- Preserve unrelated user changes.
+
+After material edits, run targeted validation and repeat only the reviews affected by the change. Use a separate verification advisor when validation is uncertain, the slice is risky, generated/dependency artifacts changed, or this is the final readiness pass.
+
+Stop after repeated findings, three cycles without progress, unavailable subagents, or when the smallest fix requires broad or unclear behavior changes.
+
+## Handoff
+
+Report only:
+
+- `garfield: pass` or `garfield: blocked`
+- validation commands and results
+- independent verification result when used
+- residual blocker/high/medium concerns
+- deferred adjacent improvements or unclear behavior changes
+
+Do not include a cycle diary or generic review advice.
+
+## Never
+
+- Never run Garfield for standalone review or non-code iteration.
+- Never substitute an agentless review for required subagents.
+- Never change APIs, permissions, defaults, validation policy, serialization, or unrelated code outside the captured intent.
+- Never revert unrelated user work.

--- a/examples/garfield/UPSTREAM.md
+++ b/examples/garfield/UPSTREAM.md
@@ -1,0 +1,9 @@
+# Upstream Source
+
+- Repository: `dcramer/agents`
+- Path: `skills/garfield`
+- Commit: `f98c348edd8f063b9d39e476b92cc59cc91b7710`
+- License: Apache-2.0
+- Retrieved: 2026-07-22
+
+The exact upstream skill snapshot is preserved under `original/`. The policy references at the example root are copied from that source under Apache-2.0. The generated spec, skill instructions, and eval cases were authored from the snapshot using Skillet's `spec.md` → `SKILL.md` → eval case workflow.

--- a/examples/garfield/evals/cases/accept-only-material-findings.yaml
+++ b/examples/garfield/evals/cases/accept-only-material-findings.yaml
@@ -1,0 +1,20 @@
+behavior: accept-only-material-findings
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to finish the current null-user formatter change. Keep the
+  exported API and do not expand this into a formatter redesign.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      The agent accepted only findings caused by the current diff, fixed the
+      missing regression coverage, and rejected or deferred unrelated API,
+      architecture, style, and hardening suggestions.
+timeout: 600

--- a/examples/garfield/evals/cases/capture-the-current-intent.yaml
+++ b/examples/garfield/evals/cases/capture-the-current-intent.yaml
@@ -1,0 +1,20 @@
+behavior: capture-the-current-intent
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to finish the current formatUser change. Preserve the exported
+  API, add the missing regression coverage, and do not redesign the module.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      Before delegating review, the agent grounded the work in the requested
+      null-user behavior, the current diff, the public API constraint,
+      repository instructions, local testing policy, and relevant validation.
+timeout: 600

--- a/examples/garfield/evals/cases/delegate-in-bounded-batches.yaml
+++ b/examples/garfield/evals/cases/delegate-in-bounded-batches.yaml
@@ -1,0 +1,20 @@
+behavior: delegate-in-bounded-batches
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to review and finish this implementation slice. Include every
+  applicable review, but keep the work limited to the current change.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      The agent used no-edit subagents for applicable reviews, kept at most
+      three Garfield reviewers open at once, collected completed reviewers
+      before starting more, and drained review agents before verification.
+timeout: 600

--- a/examples/garfield/evals/cases/fix-and-validate-the-slice.yaml
+++ b/examples/garfield/evals/cases/fix-and-validate-the-slice.yaml
@@ -1,0 +1,20 @@
+behavior: fix-and-validate-the-slice
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to finish the current formatter change and leave the slice ready
+  to hand off.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      The agent fixed the current-diff testing gap with a focused regression
+      test, ran the relevant validation, and repeated only reviews affected by
+      the material edit.
+timeout: 600

--- a/examples/garfield/evals/cases/hand-off-concisely.yaml
+++ b/examples/garfield/evals/cases/hand-off-concisely.yaml
@@ -1,0 +1,20 @@
+behavior: hand-off-concisely
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to finish the current formatter slice and give me the final
+  handoff when it is ready.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      The final response reports garfield pass or blocked, validation results,
+      independent verification when used, and only residual material or
+      deferred concerns, without a cycle diary or generic advice.
+timeout: 600

--- a/examples/garfield/evals/cases/select-reviews-from-evidence.yaml
+++ b/examples/garfield/evals/cases/select-reviews-from-evidence.yaml
@@ -1,0 +1,20 @@
+behavior: select-reviews-from-evidence
+fixture: review-slice
+setup: |
+  git init -q -b feature/null-user
+  git config user.email eval@example.com
+  git config user.name "Skillet Eval"
+  git add -A
+  git commit -qm seed
+  printf 'export const formatUser = (user) => user?.name ?? "Unknown"\n' > src/format-user.js
+prompt: |
+  Use Garfield to finish the current formatUser change. Preserve the exported
+  API and follow the repository's own testing policy.
+checks:
+  - shell: npm test
+  - shell: grep -q 'Unknown' test/format-user.test.js
+  - judge: >
+      The agent enumerated applicable and skipped review tasks from the diff,
+      treated policies/testing.md as authoritative for test quality instead of
+      duplicating the bundled testing policy, and kept unrelated policies out.
+timeout: 600

--- a/examples/garfield/evals/fixtures/review-slice/AGENTS.md
+++ b/examples/garfield/evals/fixtures/review-slice/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Instructions
+
+- Preserve the exported `formatUser` API.
+- Add focused regression coverage for behavior changes.
+- Run `npm test` before reporting completion.

--- a/examples/garfield/evals/fixtures/review-slice/package.json
+++ b/examples/garfield/evals/fixtures/review-slice/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "garfield-review-slice",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/format-user.js"
+  }
+}

--- a/examples/garfield/evals/fixtures/review-slice/policies/testing.md
+++ b/examples/garfield/evals/fixtures/review-slice/policies/testing.md
@@ -1,0 +1,7 @@
+# Testing
+
+## Policy
+
+- Test user-visible outcomes through the public API.
+- Add focused regression coverage for behavior changed by the current diff.
+- Do not mock local pure functions.

--- a/examples/garfield/evals/fixtures/review-slice/src/format-user.js
+++ b/examples/garfield/evals/fixtures/review-slice/src/format-user.js
@@ -1,0 +1,1 @@
+export const formatUser = (user) => user.name

--- a/examples/garfield/evals/fixtures/review-slice/test/format-user.js
+++ b/examples/garfield/evals/fixtures/review-slice/test/format-user.js
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { formatUser } from "../src/format-user.js"
+
+test("formats a named user", () => {
+  assert.equal(formatUser({ name: "Ada" }), "Ada")
+})

--- a/examples/garfield/original/LICENSE
+++ b/examples/garfield/original/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/garfield/original/README.md
+++ b/examples/garfield/original/README.md
@@ -1,0 +1,33 @@
+# Garfield
+
+Runtime instructions live in `SKILL.md`. Maintenance contract lives in `SPEC.md`. Provenance and decisions live in `SOURCES.md`.
+
+## Bundled Review Policies
+
+| Policy | Source |
+| --- | --- |
+| `references/code-comments.md` | Adapted from `/Users/dcramer/src/junior/policies/code-comments.md`. |
+| `references/implementation-minimalism.md` | Adapted from the 2026-06-15 user request to reduce speculative guardrails, fallbacks, edge-case handling, and tests unless required by intent. |
+| `references/interface-design.md` | Adapted from `/Users/dcramer/src/junior/policies/interface-design.md`. |
+| `references/test-quality.md` | Adapted from `getsentry/junior` PR #532 and testing architecture policy sources. |
+
+`garfield` compares bundled policies with source-app policies before applicability selection, then spawns one policy subagent per applicable policy in the effective set. All reviewers share the skill's three-open-agent rolling limit.
+
+## Source-App Policies
+
+When a source application has local policy docs, `garfield` discovers `policies/**/*.md` files whose scope or subject governs the touched slice, excluding any `README.md` or `policy-template.md` file under `policies/`.
+
+The coordinator compares policy intent and scope without repo configuration. A source-app policy supersedes a bundled policy when it establishes repo-wide defaults for substantially the same concern, even when names or wording differ. Narrower or adjacent policies supplement the bundled policy. Superseded bundled policies are excluded from review; source-app policies remain authoritative.
+
+These files are read from the repository under review at runtime. Do not vendor source-app policies into this skill or require supersession metadata in consuming repos.
+
+## Maintenance References
+
+| Reference | Use |
+| --- | --- |
+| `references/policy-template.md` | Use when adding or revising bundled policy references. |
+
+Keep bundled policy references concise:
+- short intent
+- default rules
+- real exceptions only

--- a/examples/garfield/original/SKILL.md
+++ b/examples/garfield/original/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: garfield
+description: Use while implementing code changes, after a meaningful slice, to coordinate subagent review/fix/verify loops that preserve the core user or PR intent. Fix regressions, explicit requirement mismatches, validation gaps, and behavior-preserving cleanup; report unrelated improvements or out-of-intent behavior changes instead. Do not use for standalone reviews, brainstorming, or non-code iteration.
+disable-model-invocation: true
+---
+
+After each meaningful implementation slice, coordinate subagent review, validate accepted findings, fix only what preserves the core intent, and repeat until the slice is ready.
+
+Garfield is Garfield the Cat doing the review: skeptical, concise, allergic to unnecessary work, and focused on concrete flaws rather than general advice.
+
+## Contract
+
+- Scope review to the current diff and directly related files.
+- Snapshot the core intent before review: requested behavior, intended behavior changes, compatibility expectations, touched areas, and known non-goals.
+- Preserve the core user or PR intent. Do not introduce behavior changes outside that intent.
+- Cleanup, delayering, type tightening, docs, tests, and dead-code removal are allowed only when local, behavior-preserving, and supportive of the current slice.
+- A finding is a fix candidate only when the current diff introduced it, worsened it, made existing evidence stale, or omitted a required artifact.
+- Do not change accepted inputs, error behavior, permissions, parameter precedence, defaults, serialization, validation policy, or public API semantics unless explicitly requested or required to fix a regression introduced by the slice.
+- Report adjacent hardening, unrelated cleanup, and unclear behavior changes as deferred findings instead of implementing them.
+- Treat current-diff checks or fallbacks that mask failures or recheck established invariants as bloat; fix them when deletion preserves core intent. Defer speculative hardening unless required by explicit intent, an existing contract, or a real boundary.
+- Preserve unrelated user changes. Do not revert unrelated dirty-worktree files.
+- Treat the source app as the active repository being reviewed. Discover source-app policies by sorting `policies/**/*.md` and excluding any `README.md` or `policy-template.md` file under `policies/`.
+- Before applicability selection, compare each bundled policy with the discovered source-app policies by intent and scope. A source-app policy supersedes a bundled policy when it establishes repo-wide defaults for substantially the same concern, even when names or wording differ; a narrower or adjacent policy supplements it.
+- Build one effective policy set: omit superseded bundled policies, retain supplemental policies, and never send an omitted bundled policy to a reviewer or use it to produce findings.
+- Use a no-edit subagent for every applicable review task. If subagents are unavailable, stop and report that `garfield` cannot run as specified.
+- Enumerate candidate review tasks before spawning subagents, then mark each `applicable` or `skipped` with a short diff-based reason. Do not skip a task merely because the slice looks safe.
+- Always run behavior/spec, repo-instructions, and validation review. Run other review tasks and policies only when their listed diff signals or scope apply.
+- Spawn one subagent per applicable review task or policy.
+- Keep at most 3 Garfield subagents open at once. Use a rolling spawn/wait/close/refill loop; collect and close or release completed agents before spawning more when the runtime supports it.
+- Do not launch every applicable task at once, rely on implicit runtime queuing, or repeatedly retry capacity errors. Reduce the batch to available capacity; if capacity remains unavailable after completed agents are drained, stop and report the blocker.
+- Act as coordinator: judge subagent findings for validity, reject weak findings, decide accepted/deferred findings, and implement accepted fixes.
+- Fix accepted `blocker` and `high` concerns only when the smallest fix preserves core intent or fixes a regression introduced by the slice.
+- Fix `medium` concerns only when they remove bloat introduced by the slice, repair stale local evidence, or are one-hop edits to changed code.
+- Reject vague, preference-only, or evidence-free concerns.
+- Do not loop for `low` findings only.
+- Run targeted validation after fixes.
+- Use an independent verification advisor when validation is uncertain, the slice is risky, generated/dependency artifacts changed, or this is the final readiness pass.
+
+## Concern Format
+
+```text
+[severity][evidence:<label[,label]> <locator>] path:line - concern. impact: <impact>. fix: <smallest change>.
+```
+
+Severity:
+- `blocker`: must fix before proceeding.
+- `high`: fix when the smallest fix preserves core intent.
+- `medium`: fix only when current-diff-caused and non-expanding.
+- `low`: optional; do not repeat solely for this.
+
+Evidence labels:
+- `direct`: changed code proves the concern.
+- `spec`: request/spec/contract mismatch.
+- `policy`: bundled policy, source-app policy, or repo instruction mismatch.
+- `test`: missing, weak, stale, or incorrect test/fixture/snapshot evidence.
+- `validation`: command output, skipped command, or missing check.
+- `missing`: expected docs, generated artifact, schema, migration, lockfile, or manifest change is absent.
+- `inferred`: plausible risk from control flow; never use as `blocker` without another evidence label.
+
+Use changed-code `path:line` when available. For missing artifacts or validation gaps, the locator may be a command, test name, policy/spec path, artifact path, or manifest/lockfile path.
+
+## Loop
+
+1. Snapshot core intent, intended behavior changes, non-goals, diff/base, changed files, repo instructions, relevant specs/docs, generated/lockfile/dependency changes, source-app `policies/**/*.md`, validation commands, and intentional tradeoffs.
+2. Compare bundled and source-app policies by meaning. Classify each bundled-to-local relationship as `supersedes`, `supplements`, or `unrelated`, then remove superseded bundled policies from the effective policy set. Favor a source-app policy when it clearly owns the same repo-wide concern; do not infer replacement from filename similarity alone. For example, a broad `policies/testing.md` normally supersedes bundled test quality, while a focused `policies/test-adapters.md` supplements it.
+3. Enumerate candidate reviews from the effective policy set and classify each before spawning:
+   - behavior/spec review — always: changed request/spec behavior, realistic failure paths, and user-visible contracts
+   - repo instructions review — always: repo instructions and local conventions are followed
+   - validation review — always: available checks match the touched files and behavior
+   - specs/docs review — when behavior, documented contracts, changelogs, API docs, or generated docs changed or should have changed
+   - dead code review — when paths were replaced, deleted, refactored, or may have left unused symbols or compatibility leftovers
+   - delayering review — when wrappers, flags, adapters, abstractions, indirection, or ownership boundaries changed
+   - type-boundary review — when typed interfaces, casts, nullable values, `any`, `unknown`, or serialization boundaries changed
+   - generated/dependency review — when generated artifacts, schemas, migrations, lockfiles, manifests, or dependencies changed or are required
+   - retained code-comments policy review — when comments or docstrings changed, or new non-obvious code makes comment quality material: `references/code-comments.md`
+   - retained implementation-minimalism policy review — when the slice adds guards, fallbacks, wrappers, configuration, edge-case handling, or supporting tests: `references/implementation-minimalism.md`
+   - retained interface-design policy review — when public or module interfaces, lifecycle, naming, ownership, or platform boundaries changed: `references/interface-design.md`
+   - retained test-quality policy review — when tests or fixtures changed, or changed behavior creates a concrete test obligation: `references/test-quality.md`
+   - effective source-app policy reviews — when a discovered policy's scope or subject governs the touched slice
+4. Record every candidate as `applicable` or `skipped` with a concrete diff signal or absence. Record each omitted bundled policy as `skipped — superseded by <source-app-policy-path>`. Confidence that the code is fine is not a skip reason.
+5. Queue one no-edit subagent per applicable task or effective policy. Give policy subagents only the relevant policy text plus the slice context.
+6. Process the queue with at most 3 open Garfield subagents: spawn up to capacity, wait for results, collect and close or release completed agents when supported, then refill. Drain review agents before starting the verification advisor.
+7. Coordinate findings: accept valid material concerns only when their smallest fix preserves core intent; reject invalid concerns with evidence; defer valid concerns that require out-of-intent behavior changes, adjacent hardening, unrelated cleanup, or unclear intent.
+8. Fix accepted concerns that preserve core intent.
+9. Run the smallest relevant tests, type checks, linters, builds, schema checks, or generated-artifact checks.
+10. Ask a separate subagent verification advisor only when it adds signal.
+11. Repeat after material edits.
+
+Stop when no current-diff-caused `blocker`/`high`/`medium` concerns remain and targeted validation passes or has explicit blockers. Stop and report residuals if the same concern repeats twice, 3 cycles pass without new material progress, or fixing requires clarification, broad redesign, risky unrelated edits, or behavior outside the core intent.
+
+## General Review Task Prompt
+
+```markdown
+Review this implementation slice for one review task. Review only. Do not edit. Return findings only.
+
+Review task: <one enumerated non-policy task>
+
+User goal: <request>
+Intent: <goal>
+Diff/base: <base or comparison>
+Changed files: <paths>
+Repo instructions checked: <paths>
+Specs/docs checked: <paths or none>
+Source-app policies checked: <paths or none>
+Validation: <commands and results or not run>
+Intentional tradeoffs: <notes or none>
+
+Behavior guard:
+- Return fix candidates only for concerns introduced by the current diff, worsened by it, made stale by it, or required artifacts it omitted.
+- Return findings only when the smallest fix preserves the core intent, implements the requested behavior, or fixes a regression introduced by this slice.
+- Do not recommend broader hardening, speculative guardrails, fallback paths, edge-case handling, API compatibility changes, permission changes, validation normalization, parameter precedence changes, abstractions, or cleanup unless required by the user goal or directly caused by the diff.
+- Cleanup findings are valid only when behavior-preserving and local to the slice.
+- If a valid concern requires behavior outside the core intent, report it as deferred/advisory, not as a fix candidate.
+
+Output:
+- [severity][evidence:<label[,label]> <locator>] path:line - concern. impact: <impact>. fix: <smallest change>.
+
+If no material concerns: none
+```
+
+## Policy Review Agent Prompt
+
+```markdown
+Review this implementation slice against exactly one policy. Review only. Do not edit. Return findings only.
+
+Policy source: <bundled or source-app>
+Policy reference: <policy path>
+Policy text:
+<policy text>
+
+User goal: <request>
+Intent: <goal>
+Diff/base: <base or comparison>
+Changed files: <paths>
+Repo instructions checked: <paths>
+Intentional tradeoffs: <notes or none>
+
+Behavior guard:
+- Return fix candidates only for policy violations introduced by the current diff, worsened by it, made stale by it, or required artifacts it omitted. Defer pre-existing policy debt.
+- Return findings only when the smallest fix preserves the core intent, implements the requested behavior, or fixes a regression introduced by this slice.
+- Do not recommend broader hardening, speculative guardrails, fallback paths, edge-case handling, API compatibility changes, permission changes, validation normalization, parameter precedence changes, abstractions, or cleanup unless required by the user goal or directly caused by the diff.
+- Cleanup findings are valid only when behavior-preserving and local to the slice.
+- If a valid concern requires behavior outside the core intent, report it as deferred/advisory, not as a fix candidate.
+
+Output:
+- [severity][evidence:policy <policy-reference>;cause:introduced|worsened|stale|missing-required] path:line - concern. impact: <slice impact>. fix: <smallest non-expanding change>.
+
+If no material concerns: none
+```
+
+## Verification Advisor Prompt
+
+```markdown
+Verify this implementation slice independently. Review evidence only. Do not edit. Do not re-review the whole diff.
+
+Intent: <goal>
+Changed files: <paths>
+Final diff summary: <summary>
+Validation: <commands and results or not run>
+Deferred findings: <findings with reasons or none>
+
+Check:
+- final diff preserves core intent and does not introduce out-of-intent behavior changes
+- validation commands match changed behavior and touched files
+- required test/type/lint/build/schema/generated/doc/dependency checks ran or have explicit blockers
+- deferred concerns have concrete evidence and a valid reason
+
+Output:
+- [severity][evidence:validation <command-or-missing-check>] <slice-or-path> - concern. impact: <impact>. fix: <smallest verification step>.
+
+If sufficient: verified
+```
+
+## Handoff
+
+Report only:
+
+- `garfield: pass` or `garfield: blocked`
+- validation commands/results
+- independent verification result, only if run or skipped for a non-obvious reason
+- residual accepted or deferred `blocker`/`high`/`medium` concerns, if any
+- deferred adjacent improvements or unclear behavior changes, if any

--- a/examples/garfield/original/SOURCES.md
+++ b/examples/garfield/original/SOURCES.md
@@ -1,0 +1,178 @@
+# Garfield Sources
+
+## Source Inventory
+
+| Source | Trust | Contribution | Usage |
+| --- | --- | --- | --- |
+| User seed prompt in setup request | High | Defines repeat-after-each-slice behavior, subagent advisor requirement, precision preference, and concern categories. | Adapted into runtime loop, advisor prompts, and review checklist. |
+| Local `AGENTS.md` | High | Defines repo shape, skill file expectations, no hosting config, concise docs, and validation expectations. | Drove `skills/garfield/` layout and concise docs. |
+| Local `README.md` | High | Shows install entrypoint, example `agents.toml`, and skill inventory conventions. | Updated root skill inventory and example. |
+| `/Users/dcramer/src/junior/policies/README.md` | High | Defines policy docs as short repo-wide defaults and says to keep intent, default rules, and exceptions small. | Adapted into `references/policy-template.md`. |
+| `/Users/dcramer/src/junior/policies/policy-template.md` | High | Provides the concise policy file shape. | Adapted into `references/policy-template.md`. |
+| `/Users/dcramer/src/junior/policies/code-comments.md` | High | Defines when comments/JSDoc are useful and when they are noise. | Vendored into `references/code-comments.md`. |
+| `/Users/dcramer/src/junior/policies/interface-design.md` | High | Defines narrow interface, naming, lifecycle, ownership, and platform-boundary defaults. | Vendored into `references/interface-design.md`. |
+| User test-quality policy request | High | Defines recurring bad agent-test patterns: over-mocking, weak unit defaults, duplication, and default telemetry/logging assertions. | Adapted into `references/test-quality.md` and used to replace the generic tests/fixtures review task. |
+| User test-deduping and concision requests | High | Clarifies that when a higher-fidelity test encapsulates a lower-fidelity test, Garfield should prefer higher coverage and remove the lower-fidelity duplicate; later requested tightening because more words make misses likelier. | Tightened `references/test-quality.md` to make deletion of encapsulated lower-layer tests the default, then compressed repeated testing guidance into fewer decision-focused bullets. |
+| User telemetry testing refinement | High | Clarifies that telemetry tests should be minimized rather than forbidden, and required instrumentation tests should rely on spies or capture sinks before mocks. | Tightened `references/test-quality.md` instrumentation guidance. |
+| User implementation-minimalism policy request | High | Defines recurring agent overengineering patterns: excessive guardrails, speculative edge-case handling, fallbacks, and tests for unlikely scenarios. | Adapted into `references/implementation-minimalism.md` and added as a bundled policy subagent. |
+| User defensive-code refinement request | High | Identifies excessive GPT-generated defensive code as a recurring failure mode and asks Garfield to combat it without bloating the skill. | Tightened implementation minimalism around silent fallback success, repeated invariant checks, and concise boundary-aware exceptions. |
+| [OWASP Input Validation Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html) and [Secure Cloud Architecture Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secure_Cloud_Architecture_Cheat_Sheet.html) | High | Defines early validation of untrusted external data and trust boundaries where components with different trust levels meet; also notes that trusted components need not repeat every check. | Preserved validation at real boundaries while discouraging duplicate downstream checks. |
+| User source-app policies request | High | Requests discovering local `policies/` files in the source application and running each through a policy subagent similar to bundled Garfield policies. | Added runtime source-app policy discovery and one policy subagent per discovered policy file. |
+| User policy supersession request | High | Requires removing redundant bundled policy reviews when a repo-local policy supersedes the same concern, with no repo configuration because the decision should be agentic. | Added intent-and-scope comparison and an effective policy set that excludes superseded bundled policies while retaining supplements. |
+| User subagent concurrency feedback | High | Reports that Garfield can over-spawn reviewers and asks for an explicit concurrency limit plus applicability selection before launch. | Replaced unconditional fan-out with diff-based reviewer selection and a three-open-agent rolling window. |
+| OpenAI Codex [`config/mod.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/config/mod.rs), [`agent/registry.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/agent/registry.rs), and [`agent/control/residency.rs`](https://github.com/openai/codex/blob/main/codex-rs/core/src/agent/control/residency.rs) | High | Current Codex defaults differ by runtime: classic multi-agent defaults to six child threads, Multi-Agent V2 defaults to four total active threads including the coordinator, and capacity/release behavior is runtime-specific. | Chose a portable maximum of three open Garfield subagents, explicit close/release handling, and no reliance on implicit queuing. |
+| User overengineering feedback | High | Reports that Garfield should prevent bloat while preserving tight interface design and useful comments. | Tightened current-diff causality, medium severity, policy prompts, and policy references. |
+| `getsentry/junior` PR #532 | High | Provides a concrete testing architecture cleanup, including test-layer selection, mock boundary hardening, duplication removal, and Bugbot findings around stale test scripts and unwired adapters. | Adapted into a repo-generic test-quality policy. |
+| `/Users/dcramer/src/junior` branch `origin/codex/testing-architecture-cleanup` testing docs | High | Supplies source examples from `specs/testing.md`, `specs/integration-testing.md`, `specs/component-testing.md`, `specs/unit-testing.md`, `specs/eval-testing.md`, and `policies/test-adapters.md`. | Generalized into bundled policy guidance without carrying Junior-specific paths or commands into runtime. |
+| Sidecar review of draft implementation-loop skill | High | Identified missing trigger boundaries, no-edit advisor contract, severity semantics, anti-loop rules, dirty-worktree handling, and generated/dependency checks. | Incorporated into runtime rules, loop contract, prompt schema, `SPEC.md`, and coverage notes. |
+| [Google Engineering Practices: What to look for in a code review](https://google.github.io/eng-practices/review/reviewer/looking-for.html) | High | Prior art for checking tests, documentation, style authority, maintainability, and avoiding blocking on personal style. | Reinforced test/docs/policy checks and low-severity handling. |
+| [Gerrit Review Labels documentation](https://gerrit-review.googlesource.com/Documentation/config-labels.html) | High | Prior art separating `Code-Review` from `Verified`, where verification means compilation/tests passed. | Drove separate review advisor and verification advisor concepts. |
+| [GitHub protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) and [pull request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews) | High | Prior art for required reviews, stale approvals after new commits, status checks, and most-recent-push approval by someone else. | Reinforced rerun-after-edit behavior and independent verification after material changes. |
+| [Conventional Comments](https://conventionalcomments.org/) | Medium | Prior art for labeled review comments that improve intent clarity and machine readability. | Drove explicit evidence labels in concern output. |
+| [OASIS SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html) | High | Prior art for structured analysis results with severity, message, locations, related locations, and rule identifiers. | Drove location/evidence requirements and concise diagnostic-style output. |
+| [Kubernetes Pull Request Process](https://www.kubernetes.dev/docs/guide/pull-requests/) | Medium | Prior art for test/review/edit repeat loops, trusted reviewers, `/lgtm`, `/approve`, and test reruns. | Reinforced loop semantics, independent review signals, and not fixing every weak comment. |
+| Local `skill-writer` skill instructions | High | Required workflow for skill creation, synthesis, authoring, description optimization, and validation. | Used for artifact layout, `SPEC.md`, `SOURCES.md`, and validation plan. |
+| `skill-writer/references/mode-selection.md` | High | New skill requires synthesis, authoring, description optimization, and registration/validation. | Drove selected path. |
+| `skill-writer/references/execution-shapes.md` | High | Choose simplest adequate shape; add advanced mechanics only when needed. | Drove inline runtime with a mandatory subagent advisor step and no extra references. |
+| `skill-writer/references/layout-inline-skill.md` | High | Inline layout fits the universal loop. | Drove compact `SKILL.md`; bundled policies were later split into focused references. |
+| `skill-writer/references/workflow-validation-loops.md` | High | Defines validate-fix-repeat contract and passing state. | Drove loop and stop rules. |
+| `skill-writer/references/source-adaptation.md` | High | Converts user workflow prompt into reusable skill guidance. | Drove provenance and adaptation notes. |
+| `skill-writer/references/authoring-path.md` | High | Defines frontmatter, runtime compactness, and precision pass. | Drove `SKILL.md` shape. |
+| `skill-writer/references/reference-architecture.md` | High | Separates runtime, maintenance, provenance, and optional references. | Drove `SKILL.md`, `SPEC.md`, and `SOURCES.md` boundaries. |
+| `skill-writer/references/spec-template.md` | High | Defines maintenance contract shape. | Drove `SPEC.md`. |
+| `skill-writer/references/description-optimization.md` | High | Trigger wording and false-positive checks. | Drove final description. |
+| `skill-writer/references/registration-validation.md` | High | Registration and structural validation expectations. | Drove root README update and validator command. |
+
+## Adaptation Notes
+
+| Decision | Result |
+| --- | --- |
+| Source intent | Make agents coordinate subagent review for each implementation slice, judge findings, fix valid concerns, and repeat until the code is ready. |
+| Local target | A portable skill under `skills/garfield/` that works in consuming repos such as `~/src/junior`. |
+| Fidelity boundary | Preserve mandatory subagent review, per-policy subagents, coordinator validity judgment, useful independent verification, review-fix-repeat behavior, precision/low-prose output, evidence-labeled findings, specs/docs, behavior, bundled policy, dead-code, delayering, type, generated/dependency, implementation-minimalism, test-quality, and verification checks. |
+| Local replacement | Converted narrative instructions into a compact workflow, enumerated review tasks, advisor prompts, stopping rule, bundled policy references, minimal handoff contract, and dedicated implementation-minimalism and test-quality policies. |
+| Omitted material | No provider-specific subagent API names, scripts, or references; runtimes vary and v1 behavior is short enough inline. |
+| Rights and attribution | User-authored seed prompt and local repo sources; no external licensed text bundled. |
+
+## Synthesis Decisions
+
+| Decision | Status | Rationale |
+| --- | --- | --- |
+| Skill class: `workflow-process` | adopted | The skill is a repeatable implementation operation with preconditions, ordered flow, failure handling, safety boundaries, and validation. |
+| Primary shape: inline workflow with routed policy references | adopted | The loop belongs in `SKILL.md`; exact policy text belongs in focused references for policy subagents. |
+| Secondary shape: validation loop | adopted | The skill must fix concerns, validate, and repeat until a passing state. |
+| Secondary shape: mandatory applicable review subagents | adopted | The main agent classifies candidate reviewers from concrete diff signals, spawns one subagent per applicable task, and records why other tasks were skipped. |
+| Reviewer concurrency limit | adopted | Keep at most three Garfield subagents open so the workflow fits current conservative child capacity across Codex runtimes and does not depend on runtime queuing. |
+| Rolling reviewer lifecycle | adopted | Spawn, wait, collect, close or release when supported, and refill; drain review agents before conditional verification so completed agents do not strand capacity. |
+| Bundled code-comments policy | adopted | User requested pulling this policy into the skill rather than relying on in-repo policies. |
+| Bundled implementation-minimalism policy | adopted | User requested a policy that minimizes speculative guardrails, fallbacks, edge-case handling, and related tests unless they are part of the intent. |
+| Bundled interface-design policy | adopted | User requested pulling this policy into the skill rather than relying on in-repo policies. |
+| Bundled test-quality policy | adopted | User requested replacing the weak generic test reviewer with repo-generic policy that discourages over-mocking, weak unit-test defaults, duplication, and default telemetry/logging assertions. |
+| Encapsulated lower-layer tests | adopted | User requested deduping tests when higher-fidelity coverage already proves the same behavior; preserve lower-layer tests only for distinct local invariants or meaningful failure diagnosis. |
+| Telemetry test minimization | adopted | User clarified that instrumentation tests should be rare but valid when telemetry is the contract, and should observe the real delivery path with spies or capture sinks instead of broad telemetry mocks. |
+| Dynamic source-app policy discovery | adopted | Consuming repos may have their own `policies/` docs; Garfield should review against them without vendoring app-specific rules into the portable skill. |
+| Source-app policy file set | adopted | Discover sorted `policies/**/*.md` files and exclude any `README.md` or `policy-template.md` under `policies/` because they are support docs rather than review policies. |
+| Agentic local-policy supersession | adopted | Compare policy intent and scope; repo-wide local defaults replace bundled policies for substantially the same concern even when names differ, while narrower or adjacent policies supplement them. No repo metadata or configuration is required. |
+| Generic tests/fixtures review task | replaced | Test quality needs policy-grade layer and mock analysis; the old task was too broad and encouraged "coverage match" rather than better test architecture. |
+| Non-policy review task wording | narrowed | Policy reviews are listed in the loop, so spawn wording now prevents accidentally running bundled policy subagents twice. |
+| Bundled policy template | adopted | User requested keeping policy references concise; template gives the maintenance shape. |
+| Skill README for bundled references | adopted | User requested moving bundled-reference inventory and maintenance notes out of `SKILL.md`. |
+| Independent verification advisor | adopted, conditional | Gerrit and GitHub prior art separate review judgment from verification/status checks; make this conditional so trivial slices do not pay boilerplate overhead. |
+| Severity semantics | adopted | Fix behavior needs a clear threshold; `blocker/high/medium/low` prevents loops over low-value notes. |
+| Evidence labels | adopted | Conventional Comments and SARIF prior art both favor structured labels plus locations; evidence labels make concerns reviewable without adding prose. |
+| Anti-loop stop rule | adopted | Stop after repeated concerns or 3 cycles without material progress; do not stop merely because a fixed cycle count was reached. |
+| Review-only advisor contract | adopted | Keeps the main agent accountable for applying or rejecting findings. |
+| Discrete applicable review tasks plus per-policy review | adopted | Behavior/spec, repo instructions, and validation always run; other task and policy reviewers run only when concrete diff signals or scope make them material. |
+| Coordinator role | adopted | The main agent must evaluate validity of subagent findings instead of treating advisor output as authoritative. |
+| Cycle output | rejected | Per-cycle logs are mostly bookkeeping; the skill should track loops internally and report only validation plus residual material concerns. |
+| Scripts | rejected | No deterministic parsing or automation is required for v1. |
+| Runtime references | adopted | Bundled policy text belongs in `references/` so policy subagents receive exact policy content without relying on consuming repos. |
+| Runtime minimalism | adopted | Removed the runtime H1, cross-skill routing, bundled-reference inventory, and maintenance notes from `SKILL.md`. |
+| Provider-specific mechanics | rejected | The runtime requires subagents but avoids provider-specific API names; runtimes without subagents should report that the skill cannot run as specified. |
+| Invocation control | adopted | Added `disable-model-invocation: true` for Claude Code and `policy.allow_implicit_invocation: false` in `agents/openai.yaml` for Codex so both runtimes keep Garfield user-invoked only. |
+| `SPEC.md` | adopted | The skill has non-trivial trigger, loop, evidence, and validation contracts. |
+| README registration | adopted | The repo maintains a root skill inventory and example install config. |
+
+## Coverage Matrix
+
+| Dimension | Covered By | Status |
+| --- | --- | --- |
+| Preconditions | Define slice: status, diff, repo instructions, specs/docs, tests, generated artifacts, lockfiles, dependencies, and bundled and source-app policies. | covered |
+| Ordered flow | Agentic policy supersession, applicability classification, then rolling spawn/wait/close/refill loop. | covered |
+| Failure handling | Subagent-unavailable stop, capacity blocker handling, validation blocker reporting, recurring-concern handling. | covered |
+| Safety boundaries | Advisor-not-authority rule, review-only advisor, high-confidence/material concern filter, dirty-worktree preservation, product intent boundary. | covered |
+| Output contract | Minimal handoff status and residual material concerns only. | covered |
+| Evidence labels | Evidence section and reviewer output schema. | covered |
+| Independent verification | Conditional verification advisor prompt and handoff status. | covered |
+| Policy compliance | `references/code-comments.md`, `references/implementation-minimalism.md`, `references/interface-design.md`, `references/test-quality.md`, and policy subagent prompt. | covered |
+| Source-app policy compliance | Runtime discovery of source-app `policies/**/*.md` and one policy subagent per discovered file. | covered |
+| Redundant policy removal | Intent-and-scope comparison builds one effective policy set and excludes superseded bundled policies without repo configuration. | covered |
+| Specs/docs | Advisor checklist and slice definition. | covered |
+| Dead code and delayering | Advisor checklist and fix categories. | covered |
+| Implementation minimalism | `references/implementation-minimalism.md`, policy subagent prompt, and core-intent behavior gate. | covered |
+| Type quality | Advisor checklist. | covered |
+| Generated/dependency drift | Slice definition and advisor checklist. | covered |
+| Test quality | `references/test-quality.md`, policy subagent prompt, and validation advisor. | covered |
+| Verification | Validate step and final output. | covered |
+| Portability | Skill-root-local files and no provider-specific tool names. | covered |
+
+## Description Optimization
+
+Should trigger:
+- "run garfield on this feature slice"
+- "after implementing this, use a subagent to review and fix concerns"
+- "run an independent verification pass after fixing review concerns"
+- "review/fix/repeat this code change until it is ready"
+- "use garfield after each incremental code change"
+- "check specs, policies, dead code, delayering, and types before final handoff"
+- "review this slice with the bundled code-comments and interface-design policies"
+- "run garfield and check whether the tests are over-mocked or duplicated"
+- "run garfield and flag speculative guardrails, fallbacks, and edge-case tests"
+
+Should not trigger:
+- "review this branch for cleanup"
+- "run a strict maintainability review"
+- "fix CI failures on this PR"
+- "explain this function"
+- "create a new skill"
+- "brainstorm product requirements"
+- "iterate on the UX concept"
+
+Final description:
+
+> Use while implementing code changes, after a meaningful slice, to coordinate subagent review/fix/verify loops that preserve the core user or PR intent. Fix regressions, explicit requirement mismatches, validation gaps, and behavior-preserving cleanup; report unrelated improvements or out-of-intent behavior changes instead. Do not use for standalone reviews, brainstorming, or non-code iteration.
+
+## Gaps
+
+- No real positive or negative iteration examples have been captured yet.
+- No automated semantic validator exists for advisor quality or concern materiality.
+- Subagent capacity and release behavior differ by consuming runtime; sessions already using agent slots may leave fewer than three available.
+- Source-app policy discovery uses a simple Markdown glob and may need refinement if consuming repos store policy docs outside `policies/`.
+- Semantic supersession may need tuning from real runs when local policies partially overlap broad bundled policies.
+- Evidence label taxonomy is intentionally small and may need revision after real use in `~/src/junior`.
+- Implementation-minimalism policy still needs tuning against real accepted/rejected Garfield findings.
+- Test-quality policy is generalized from one large PR and should be tuned against more repos after real use.
+
+## Changelog
+
+- 2026-06-08: Created initial inline implementation-loop skill, specification, source record, and root README inventory entry.
+- 2026-06-08: Added evidence-labeled concerns and conditional independent verification advisor contract based on prior art review; rejected per-cycle reporting as low-signal bookkeeping.
+- 2026-06-08: Tightened runtime wording around minimal handoff, conditional verification, evidence labels, and anti-loop behavior.
+- 2026-06-08: Made subagent review mandatory for every review task and clarified the main agent's coordinator role for finding validity.
+- 2026-06-08: Added bundled policy references for code comments and interface design, added a policy template reference, and changed review flow to discrete review tasks plus one subagent per bundled review policy.
+- 2026-06-08: Split the broad general implementation review into separate subagent tasks for behavior/spec, specs/docs, repo instructions, dead code, delayering, type boundaries, tests/fixtures, generated/dependencies, and validation.
+- 2026-06-08: Removed `SKILL.md` H1, cross-skill references, and bundled/maintenance inventory; added skill README for that context.
+- 2026-06-08: Added bundled test-quality policy from Junior PR #532 lessons and replaced the generic tests/fixtures review task with a policy subagent.
+- 2026-06-09: Tightened the test-quality policy to prohibit default assertions on logs, Sentry, tracing, metrics, analytics, or telemetry unless instrumentation output is the explicit contract under test.
+- 2026-06-09: Added a core-intent behavior gate so subagent findings and fixes may clean up locally but must not introduce out-of-intent behavior changes, adjacent hardening, API policy changes, or unrelated cleanup.
+- 2026-06-15: Added an implementation-minimalism policy to flag speculative guardrails, fallbacks, edge-case handling, and related tests unless required by explicit intent or real boundaries.
+- 2026-06-15: Renamed the skill from `iterate` to `garfield` and added the Garfield the Cat review persona note without changing runtime behavior.
+- 2026-06-15: Added source-app `policies/**/*.md` discovery and one policy subagent per discovered policy.
+- 2026-06-16: Added `agents/openai.yaml` with OpenAI UI metadata; runtime behavior remains defined by `SKILL.md`.
+- 2026-06-26: Tightened policy and medium finding gates so Garfield fixes only current-diff-caused concerns and defers pre-existing or patch-expanding advice.
+- 2026-06-30: Tightened test-quality policy to prefer deleting lower-fidelity tests fully encapsulated by higher-fidelity coverage, while retaining distinct invariant or diagnostic tests; compressed repeated guidance into fewer decision-focused bullets.
+- 2026-07-03: Refined test-quality policy to minimize telemetry assertions while preferring spies or capture sinks over mocks when instrumentation is the requested contract.
+- 2026-07-10: Tightened implementation minimalism against excessive defensive code: silent fallback success, repeated invariant checks, and hypothetical guards, while preserving validation at real trust boundaries.
+- 2026-07-10: Added diff-based reviewer applicability selection and limited Garfield to a rolling window of three open subagents with explicit drain behavior instead of unconditional fan-out or implicit queuing.
+- 2026-07-11: Made Garfield explicitly user-invoked in Claude Code and Codex with their respective invocation-policy metadata.
+- 2026-07-12: Added agentic source-app policy supersession so repo-wide local defaults replace redundant bundled policy reviews by intent and scope without repo configuration.

--- a/examples/garfield/original/SPEC.md
+++ b/examples/garfield/original/SPEC.md
@@ -1,0 +1,99 @@
+# Garfield Specification
+
+## Intent
+
+`garfield` is a reusable implementation hardening loop. It runs while actively implementing, after each meaningful code slice, snapshots the core user or PR intent, selects applicable review tasks from diff evidence, delegates each applicable task to a no-edit subagent in bounded rolling batches, coordinates validity of the subagents' findings, fixes accepted material concerns only when the smallest fix preserves that core intent, validates the result, asks a separate verification advisor only when it adds signal, and repeats until current-diff-caused blocker/high/medium concerns are gone.
+
+## Scope
+
+In scope:
+- incremental feature or fix implementation slices
+- current-diff review and directly related files
+- behavior-preserving cleanup, delayering, type tightening, docs, tests, and dead-code removal that support the current slice
+- fix candidates introduced, worsened, made stale, or omitted by the current diff
+- mandatory subagent-backed advisory review for every applicable review task
+- applicable effective-policy review after source-app policies supersede bundled policies that govern substantially the same concern
+- independent verification advice for risky slices, ambiguous validation, or final readiness checks
+- fixing material concerns found by the review
+- targeted tests, type checks, linters, builds, and explicit validation blockers
+- specs/docs, effective policy compliance, dead code, delayering, type contracts, generated artifacts, dependency drift, implementation minimalism, and test quality
+
+Out of scope:
+- review-only branch audits with no implementation authority
+- full PR CI iteration or external reviewer response loops
+- broad rewrites unrelated to the current slice
+- behavior changes outside the core user or PR intent
+- adjacent hardening, compatibility changes, API policy changes, permission semantics changes, validation normalization, parameter precedence changes, serialization changes, or default changes not explicitly requested and not required to fix a regression introduced by the slice
+- aesthetic-only style feedback unless required by a bundled or source-app policy
+- product requirement changes without user approval
+- non-code brainstorming or generic iteration
+
+## Users And Trigger Context
+
+- Primary users: agents implementing code who need a tight subagent-backed hardening loop before handoff.
+- Invocation: user-invoked only; the model must not activate Garfield automatically.
+- Common user requests: "run garfield on this feature slice", "use garfield after each code slice", "review/fix/repeat this implementation", "use a subagent to find concerns before you finish".
+- Should not trigger for: standalone code review requests, PR CI failure loops, harsh maintainability audits, general brainstorming, documentation-only explanation, non-code iteration, or requests to create/update skills.
+
+## Runtime Contract
+
+- Required first actions: inspect status, diff/base, repo instructions, relevant specs/docs, relevant tests, generated artifacts, lockfiles, bundled policy references, discovered source-app policies, their intent-and-scope relationships, and the core intent including intended behavior changes, compatibility expectations, touched areas, and known non-goals.
+- Required outputs: no cycle log; final status with validation run, independent verification result when used, and residual material concerns only.
+- Non-negotiable constraints: compare bundled and discovered source-app policies by intent and scope; omit a bundled policy when a source-app policy establishes repo-wide defaults for substantially the same concern, regardless of names or wording; retain narrower or adjacent policies as supplements; enumerate candidate review tasks across behavior/spec, specs/docs, repo instructions, dead code, delayering, type boundaries, generated/dependencies, validation, and the resulting effective policy set; always run behavior/spec, repo-instructions, and validation review; classify every other task or effective policy as applicable or skipped from concrete diff evidence and scope; use one review-only subagent per applicable task or effective policy; never send an omitted bundled policy to a reviewer or use it for findings; keep at most 3 Garfield subagents open through a rolling spawn/wait/close/refill loop; do not rely on implicit runtime queuing; drain review agents before conditional verification; stop if subagents or required capacity are unavailable; coordinate validity instead of accepting findings automatically; use a separate verification advisor only when it adds signal; require evidence labels, cause, and concrete locators for policy concerns; apply only high-confidence accepted material concerns whose smallest fix preserves core intent and does not expand the patch; defer valid concerns that require out-of-intent behavior changes, pre-existing policy cleanup, or speculative hardening; preserve unrelated user changes; repeat after material edits; avoid unbounded loops; and do not stop with unresolved current-diff-caused blocker/high/medium concerns unless blocked or explicitly deferred.
+- Expected bundled files loaded at runtime: `SKILL.md` and `references/code-comments.md`, `references/implementation-minimalism.md`, `references/interface-design.md`, and `references/test-quality.md` for effective-policy comparison and retained bundled-policy review.
+
+## Source And Evidence Model
+
+Authoritative sources:
+- the user's seed prompt
+- local repo instructions
+- the effective policy set derived from bundled policy references and discovered source-app policies under `policies/**/*.md`
+- the core user or PR intent and explicit non-goals
+- changed code, related specs/docs, and tests
+- generated artifacts, lockfiles, schemas, and dependency manifests
+- validation command output
+- independent verification advisor output when used
+
+Useful improvement sources:
+- positive examples: loops that caught real spec, policy, type, or dead-code issues before handoff
+- negative examples: loops that accepted vague advice, over-refactored, or stopped before material concerns were resolved
+- commit logs/changelogs: regressions caused by missing docs, weak types, or stale layers
+- issue or PR feedback: recurring reviewer comments about the loop missing concerns
+- validation results: commands that caught or failed to catch slice regressions
+- source-app policy docs: recurring local engineering rules that should replace or supplement bundled Garfield policies according to intent and scope
+
+Data that must not be stored:
+- secrets
+- customer data
+- private URLs or identifiers not needed for reproduction
+
+## Reference Architecture
+
+- `SKILL.md` contains: runtime intent, workflow, advisor prompts, concern rubric, source-app policy discovery and supersession, review-task enumeration, loop rules, and output contract.
+- `README.md` contains: bundled policy inventory and maintenance reference notes.
+- `references/` contains: bundled policy references and the policy template.
+- `references/evidence/` contains: future redacted examples if recurring loop failures justify persistent evidence.
+- `scripts/` contains: nothing yet.
+- `assets/` contains: nothing yet.
+
+## Validation
+
+- Lightweight validation: run the skill structural validator and manually inspect trigger wording, runtime compactness, anti-loop rules, severity semantics, evidence labels, independent verification, and portability.
+- Deeper validation: run the skill against real implementation slices and check whether it finds actionable, line-grounded concerns without drifting into broad prose.
+- Holdout examples: add only after enough real positive and negative loop outcomes exist.
+- Acceptance gates: valid frontmatter, concise runtime body, runtime policy references routed from `SKILL.md`, agentic local-over-bundled policy supersession, clear loop stopping rule, severity semantics, evidence-labeled findings, mandatory no-edit review subagent contract, coordinator validity role, useful-but-not-mandatory independent verification contract, and no missing runtime references.
+
+## Known Limitations
+
+- Subagent availability, capacity, release, and isolation semantics vary by agent runtime; the three-agent rolling window is conservative but cannot guarantee capacity in a session already using subagents.
+- Review quality depends on giving each advisor enough diff, spec, policy, and validation context.
+- Intent-and-scope supersession is a semantic judgment; ambiguous policy relationships may still produce redundant or missing review coverage and should be tuned from real runs.
+- Independent verification can confirm evidence coverage, not prove correctness beyond available commands and inspected artifacts.
+- The skill can over-loop on subjective concerns unless the main agent rejects weak, pre-existing, or expanding advice explicitly.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when loop behavior, advisor prompts, evidence labels, stopping rules, concern categories, source-app policy discovery or supersession, or output contract changes.
+- Update `references/` when bundled policies change; keep policy references short using `references/policy-template.md`.
+- Update `SOURCES.md` when adding provenance, decisions, gaps, or changelog entries.
+- Update `references/evidence/` only with redacted examples that materially improve future loop behavior.

--- a/examples/garfield/original/agents/openai.yaml
+++ b/examples/garfield/original/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Garfield"
+  short_description: "Review-fix-verify implementation slices"
+  default_prompt: "Use $garfield to review and harden this implementation slice before handoff."
+policy:
+  allow_implicit_invocation: false

--- a/examples/garfield/original/references/code-comments.md
+++ b/examples/garfield/original/references/code-comments.md
@@ -1,0 +1,20 @@
+# Code Comments Policy
+
+## Intent
+
+Comments explain non-obvious intent, module ownership, invariants, and tradeoffs. They should not narrate obvious code.
+
+## Policy
+
+- Major entry-point modules need a short design comment covering ownership, boundary, and key invariants.
+- Exported functions need a brief JSDoc comment explaining intent.
+- Private functions need JSDoc when they define an internal interface: handlers/factories, wire or storage formats, signing, durable state changes, reply gates, or retry/resume/compaction/session policy.
+- Comment non-obvious invariants, tradeoffs, and policy-driven behavior.
+- Keep comments short, concrete, and current.
+- Apply this policy to new or changed boundaries, stale touched comments, and behavior made non-obvious by the slice.
+
+## Exceptions
+
+- Do not comment obvious transformations or control flow.
+- Do not add comments that simply restate the code in English.
+- Small obvious leaf helpers do not need comments.

--- a/examples/garfield/original/references/implementation-minimalism.md
+++ b/examples/garfield/original/references/implementation-minimalism.md
@@ -1,0 +1,20 @@
+# Implementation Minimalism Policy
+
+## Intent
+
+Implementation slices should solve the requested problem without accumulating speculative guardrails, fallbacks, abstractions, or tests for unlikely states. Defensive code is useful at real boundaries; inside established invariants it often hides defects by converting failures into plausible success.
+
+## Policy
+
+- Implement the smallest clear behavior that satisfies the user goal, existing contract, and validation evidence.
+- Do not add defensive checks, broad catches, fallback/default values, retries, compatibility shims, abstractions, or normalization for hypothetical states.
+- Trust established types, validated inputs, and ownership boundaries instead of rechecking impossible or already-excluded conditions.
+- Do not turn missing required data, invariant violations, or unexpected failures into empty, default, stale, or otherwise successful results unless the contract requires that fallback.
+- Remove current-diff guards and adapters that duplicate upstream validation, are unreachable, or only support imagined callers or states.
+- Do not add tests solely to justify speculative guardrails. Tests should prove requested behavior, existing contracts, real regressions, or realistic boundary failures.
+
+## Exceptions
+
+- Validate untrusted input and external-system output at the earliest practical trust boundary; avoid repeating the same validation downstream.
+- Guardrails are appropriate when required by the explicit user goal, product spec, public API contract, security or permission boundary, data integrity boundary, migration compatibility, or a concrete regression introduced by the slice.
+- A cheap local assertion is acceptable when it clarifies a critical invariant and fails visibly rather than inventing recovery behavior.

--- a/examples/garfield/original/references/interface-design.md
+++ b/examples/garfield/original/references/interface-design.md
@@ -1,0 +1,35 @@
+# Interface Design Policy
+
+## Intent
+
+Interfaces should expose the smallest useful capability while keeping ownership, lifecycle, and security boundaries obvious. Module paths, file names, type names, and function names are all part of that interface.
+
+## Policy
+
+- Prefer narrow capability methods over broad dependency bags or access to underlying services.
+- Expose lifecycle-oriented operations, such as `dispatch` and `get`, instead of raw runners, clients, routes, or storage adapters.
+- Return projections by default. Do not expose full internal records when callers only need status, ids, or summaries.
+- Make ownership explicit in the API boundary. A caller should only read or mutate records it owns unless cross-owner access is the feature.
+- Keep platform details inside the layer that owns the platform. Do not leak Slack clients, Vercel primitives, Redis clients, or model-runtime internals through feature interfaces.
+- Require idempotency keys for APIs that create durable work from retryable contexts.
+- Use short JavaScript-facing names for public types and methods. Avoid framework-style names that describe implementation mechanics instead of product intent.
+- Use the same domain noun for the same concept across types, fields, functions, storage keys, and docs. Two names should mean two concepts, not two layers of the same concept.
+- Prefer simple domain nouns such as `Destination`, `Conversation`, and `Lease` over names that combine the concept with its storage shape.
+- Avoid suffixes such as `Record`, `State`, `Data`, `Payload`, `Manager`, and `Handler` unless that storage shape, lifecycle, or adapter role is the actual boundary being named.
+- Spend local context instead of repeating it. A function imported from `state/session-log` can be `commitMessages`; it does not need to be `commitAgentSessionLogMessages`.
+- Spend parent-object context in field names. Inside `Conversation`, prefer `execution`, `destination`, and `requester` over names that repeat `Conversation`.
+- Let folders and file names carry domain context. Prefer `state/session-log.ts` over `state/agent-session-log-store.ts`, and avoid names that repeat parent directories, suffix every file with its technical role, or encode the whole call path.
+- Name modules by the concern they own, not by the adapter or mechanism they happen to use. `session-log` is better than `redis-session-log` when Redis is only one backing implementation.
+- Name indexes, queues, and storage keys by their membership and ordering when they serve multiple consumers. `conversation:active` and `conversation:by-activity` describe the data contract better than process-specific names such as `recovery`.
+- Keep exported interfaces role-shaped and small. `SessionLogStore` with `read` and `append` is clearer than a broad adapter that exposes unrelated state, Redis, or queue details.
+- Prefer import-site readability over globally unique names. If a name is only clear because it includes five qualifiers, the module boundary is probably doing too little work.
+- When a term is overloaded in the product or platform, define it once in the owning spec and avoid using it for nearby concepts.
+- Add an interface only when it removes real coupling or represents a stable boundary.
+- Flag only new or changed boundaries, or names made misleading by this slice. Defer naming-only concerns unless they obscure ownership, lifecycle, security, or call-site meaning.
+
+## Exceptions
+
+- Test fixtures may expose narrower construction seams when the production interface remains small.
+- Low-level infrastructure modules may expose mechanism-specific APIs inside their own ownership boundary.
+- Generic names are acceptable inside a tightly scoped module when the import path supplies the missing context. Use longer names only when two imported roles would otherwise collide at common call sites.
+- Compatibility names may remain at external boundaries or legacy storage keys. New internal names should still normalize to the current domain term.

--- a/examples/garfield/original/references/policy-template.md
+++ b/examples/garfield/original/references/policy-template.md
@@ -1,0 +1,25 @@
+# Policy Template
+
+Use this shape when adding bundled policy references. Policies are short repo-wide defaults, not architecture documents or feature specs.
+
+Keep policy docs small:
+- explain the intent briefly
+- state the default rule clearly
+- call out only meaningful exceptions
+
+```markdown
+# Policy Name
+
+## Intent
+
+One short paragraph on why this policy exists.
+
+## Policy
+
+- Default rule
+- Second rule if needed
+
+## Exceptions
+
+- Only list real exceptions
+```

--- a/examples/garfield/original/references/test-quality.md
+++ b/examples/garfield/original/references/test-quality.md
@@ -1,0 +1,22 @@
+# Test Quality Policy
+
+## Intent
+
+Tests should prove real contracts with the least brittle machinery. Prefer moving, narrowing, or deleting weak tests over adding low-fidelity coverage.
+
+## Policy
+
+- Use the highest-fidelity deterministic layer: end-to-end for user behavior, integration for wiring and external boundaries, component for cross-module contracts, unit for local invariants. Do not default to unit tests for product behavior.
+- Prefer one strong contract test. Delete lower-fidelity duplicates fully covered by a higher-fidelity test unless they prove a distinct local invariant or materially improve failure diagnosis.
+- Use real modules, shared fixtures, in-memory adapters, test clients/servers, and protocol-level HTTP interception before mocks. Mock or fake one explicit boundary only.
+- Treat broad module mocks, global `fetch` mocks, singleton seams, generic dependency bags, and production dependency parameters for local helpers as signs the test is in the wrong layer.
+- Name harness ports for real boundaries: model replies, queue wakeups, state storage, HTTP, sandbox execution, external delivery.
+- Assert outcomes, durable state, external payloads, or user-visible behavior. Do not assert internal calls, call counts, prompt prose, or implementation identifiers. Minimize logs, spans, Sentry events, metrics, analytics, tracing, and telemetry assertions; use them only when instrumentation output is the requested contract, and prefer spying on or capturing the real delivery path over mocking telemetry modules.
+- Centralize recurring setup in shared fixtures with narrow read-only inspection, such as outboxes or captured deliveries. Do not expose broad mutable internals.
+- When tests, fixtures, scripts, or boundary checks change, verify commands, coverage scripts, and generated test artifacts still point at the new names.
+- Add tests only for requested behavior, existing contracts, real regressions, or realistic boundaries touched by the slice.
+
+## Exceptions
+
+- Local fakes or module mocks are acceptable for one explicit boundary in a pure unit or component invariant when no shared adapter expresses the case clearly.
+- Third-party SDK clients and nondeterministic system boundaries may be mocked when a protocol-level interceptor or shared test adapter is impractical.

--- a/examples/garfield/references/code-comments.md
+++ b/examples/garfield/references/code-comments.md
@@ -1,0 +1,20 @@
+# Code Comments Policy
+
+## Intent
+
+Comments explain non-obvious intent, module ownership, invariants, and tradeoffs. They should not narrate obvious code.
+
+## Policy
+
+- Major entry-point modules need a short design comment covering ownership, boundary, and key invariants.
+- Exported functions need a brief JSDoc comment explaining intent.
+- Private functions need JSDoc when they define an internal interface: handlers/factories, wire or storage formats, signing, durable state changes, reply gates, or retry/resume/compaction/session policy.
+- Comment non-obvious invariants, tradeoffs, and policy-driven behavior.
+- Keep comments short, concrete, and current.
+- Apply this policy to new or changed boundaries, stale touched comments, and behavior made non-obvious by the slice.
+
+## Exceptions
+
+- Do not comment obvious transformations or control flow.
+- Do not add comments that simply restate the code in English.
+- Small obvious leaf helpers do not need comments.

--- a/examples/garfield/references/implementation-minimalism.md
+++ b/examples/garfield/references/implementation-minimalism.md
@@ -1,0 +1,20 @@
+# Implementation Minimalism Policy
+
+## Intent
+
+Implementation slices should solve the requested problem without accumulating speculative guardrails, fallbacks, abstractions, or tests for unlikely states. Defensive code is useful at real boundaries; inside established invariants it often hides defects by converting failures into plausible success.
+
+## Policy
+
+- Implement the smallest clear behavior that satisfies the user goal, existing contract, and validation evidence.
+- Do not add defensive checks, broad catches, fallback/default values, retries, compatibility shims, abstractions, or normalization for hypothetical states.
+- Trust established types, validated inputs, and ownership boundaries instead of rechecking impossible or already-excluded conditions.
+- Do not turn missing required data, invariant violations, or unexpected failures into empty, default, stale, or otherwise successful results unless the contract requires that fallback.
+- Remove current-diff guards and adapters that duplicate upstream validation, are unreachable, or only support imagined callers or states.
+- Do not add tests solely to justify speculative guardrails. Tests should prove requested behavior, existing contracts, real regressions, or realistic boundary failures.
+
+## Exceptions
+
+- Validate untrusted input and external-system output at the earliest practical trust boundary; avoid repeating the same validation downstream.
+- Guardrails are appropriate when required by the explicit user goal, product spec, public API contract, security or permission boundary, data integrity boundary, migration compatibility, or a concrete regression introduced by the slice.
+- A cheap local assertion is acceptable when it clarifies a critical invariant and fails visibly rather than inventing recovery behavior.

--- a/examples/garfield/references/interface-design.md
+++ b/examples/garfield/references/interface-design.md
@@ -1,0 +1,35 @@
+# Interface Design Policy
+
+## Intent
+
+Interfaces should expose the smallest useful capability while keeping ownership, lifecycle, and security boundaries obvious. Module paths, file names, type names, and function names are all part of that interface.
+
+## Policy
+
+- Prefer narrow capability methods over broad dependency bags or access to underlying services.
+- Expose lifecycle-oriented operations, such as `dispatch` and `get`, instead of raw runners, clients, routes, or storage adapters.
+- Return projections by default. Do not expose full internal records when callers only need status, ids, or summaries.
+- Make ownership explicit in the API boundary. A caller should only read or mutate records it owns unless cross-owner access is the feature.
+- Keep platform details inside the layer that owns the platform. Do not leak Slack clients, Vercel primitives, Redis clients, or model-runtime internals through feature interfaces.
+- Require idempotency keys for APIs that create durable work from retryable contexts.
+- Use short JavaScript-facing names for public types and methods. Avoid framework-style names that describe implementation mechanics instead of product intent.
+- Use the same domain noun for the same concept across types, fields, functions, storage keys, and docs. Two names should mean two concepts, not two layers of the same concept.
+- Prefer simple domain nouns such as `Destination`, `Conversation`, and `Lease` over names that combine the concept with its storage shape.
+- Avoid suffixes such as `Record`, `State`, `Data`, `Payload`, `Manager`, and `Handler` unless that storage shape, lifecycle, or adapter role is the actual boundary being named.
+- Spend local context instead of repeating it. A function imported from `state/session-log` can be `commitMessages`; it does not need to be `commitAgentSessionLogMessages`.
+- Spend parent-object context in field names. Inside `Conversation`, prefer `execution`, `destination`, and `requester` over names that repeat `Conversation`.
+- Let folders and file names carry domain context. Prefer `state/session-log.ts` over `state/agent-session-log-store.ts`, and avoid names that repeat parent directories, suffix every file with its technical role, or encode the whole call path.
+- Name modules by the concern they own, not by the adapter or mechanism they happen to use. `session-log` is better than `redis-session-log` when Redis is only one backing implementation.
+- Name indexes, queues, and storage keys by their membership and ordering when they serve multiple consumers. `conversation:active` and `conversation:by-activity` describe the data contract better than process-specific names such as `recovery`.
+- Keep exported interfaces role-shaped and small. `SessionLogStore` with `read` and `append` is clearer than a broad adapter that exposes unrelated state, Redis, or queue details.
+- Prefer import-site readability over globally unique names. If a name is only clear because it includes five qualifiers, the module boundary is probably doing too little work.
+- When a term is overloaded in the product or platform, define it once in the owning spec and avoid using it for nearby concepts.
+- Add an interface only when it removes real coupling or represents a stable boundary.
+- Flag only new or changed boundaries, or names made misleading by this slice. Defer naming-only concerns unless they obscure ownership, lifecycle, security, or call-site meaning.
+
+## Exceptions
+
+- Test fixtures may expose narrower construction seams when the production interface remains small.
+- Low-level infrastructure modules may expose mechanism-specific APIs inside their own ownership boundary.
+- Generic names are acceptable inside a tightly scoped module when the import path supplies the missing context. Use longer names only when two imported roles would otherwise collide at common call sites.
+- Compatibility names may remain at external boundaries or legacy storage keys. New internal names should still normalize to the current domain term.

--- a/examples/garfield/references/policy-template.md
+++ b/examples/garfield/references/policy-template.md
@@ -1,0 +1,25 @@
+# Policy Template
+
+Use this shape when adding bundled policy references. Policies are short repo-wide defaults, not architecture documents or feature specs.
+
+Keep policy docs small:
+- explain the intent briefly
+- state the default rule clearly
+- call out only meaningful exceptions
+
+```markdown
+# Policy Name
+
+## Intent
+
+One short paragraph on why this policy exists.
+
+## Policy
+
+- Default rule
+- Second rule if needed
+
+## Exceptions
+
+- Only list real exceptions
+```

--- a/examples/garfield/references/test-quality.md
+++ b/examples/garfield/references/test-quality.md
@@ -1,0 +1,22 @@
+# Test Quality Policy
+
+## Intent
+
+Tests should prove real contracts with the least brittle machinery. Prefer moving, narrowing, or deleting weak tests over adding low-fidelity coverage.
+
+## Policy
+
+- Use the highest-fidelity deterministic layer: end-to-end for user behavior, integration for wiring and external boundaries, component for cross-module contracts, unit for local invariants. Do not default to unit tests for product behavior.
+- Prefer one strong contract test. Delete lower-fidelity duplicates fully covered by a higher-fidelity test unless they prove a distinct local invariant or materially improve failure diagnosis.
+- Use real modules, shared fixtures, in-memory adapters, test clients/servers, and protocol-level HTTP interception before mocks. Mock or fake one explicit boundary only.
+- Treat broad module mocks, global `fetch` mocks, singleton seams, generic dependency bags, and production dependency parameters for local helpers as signs the test is in the wrong layer.
+- Name harness ports for real boundaries: model replies, queue wakeups, state storage, HTTP, sandbox execution, external delivery.
+- Assert outcomes, durable state, external payloads, or user-visible behavior. Do not assert internal calls, call counts, prompt prose, or implementation identifiers. Minimize logs, spans, Sentry events, metrics, analytics, tracing, and telemetry assertions; use them only when instrumentation output is the requested contract, and prefer spying on or capturing the real delivery path over mocking telemetry modules.
+- Centralize recurring setup in shared fixtures with narrow read-only inspection, such as outboxes or captured deliveries. Do not expose broad mutable internals.
+- When tests, fixtures, scripts, or boundary checks change, verify commands, coverage scripts, and generated test artifacts still point at the new names.
+- Add tests only for requested behavior, existing contracts, real regressions, or realistic boundaries touched by the slice.
+
+## Exceptions
+
+- Local fakes or module mocks are acceptable for one explicit boundary in a pure unit or component invariant when no shared adapter expresses the case clearly.
+- Third-party SDK clients and nondeterministic system boundaries may be mocked when a protocol-level interceptor or shared test adapter is impractical.

--- a/examples/garfield/spec.md
+++ b/examples/garfield/spec.md
@@ -1,0 +1,85 @@
+# Garfield
+
+## Intent
+
+Coordinate subagent review while an agent is implementing code. Garfield keeps the current user or PR intent fixed, selects review tasks from the actual diff, delegates those reviews in bounded batches, fixes only material current-diff issues, and validates the result before handoff.
+
+The skill exists to harden an implementation slice without turning review into a broad redesign, unrelated cleanup pass, or standalone audit.
+
+## Triggers
+
+- **SHOULD** apply when the user asks to use Garfield during implementation, after a meaningful code slice, or before handing off a current change
+- **SHOULD** apply when the user asks for a review, fix, and verification pass that may use subagents
+- **SHOULD NOT** apply to standalone read-only reviews, brainstorming, non-code work, or PR CI iteration
+- **SHOULD NOT** activate automatically without an explicit request
+
+## Behaviors
+
+### Behavior: Capture the Current Intent
+
+The agent SHALL record the requested behavior, intended changes, compatibility expectations, touched areas, non-goals, current diff, repository instructions, relevant specs, and available validation before delegating review.
+
+#### Scenario: Review an Authentication Change
+
+- **WHEN** the user asks for Garfield after implementing an authentication fix
+- **THEN** the agent states the intended authentication behavior and non-goals, inspects the current diff and repository guidance, and uses that snapshot for every review decision
+
+### Behavior: Select Reviews From Evidence
+
+The agent SHALL enumerate candidate review tasks, mark each applicable or skipped from concrete diff signals, and combine bundled policies with repository policies without duplicating a concern that the repository already governs.
+
+#### Scenario: Repository Policy Replaces a Bundled Policy
+
+- **GIVEN** the changed repository has a repo-wide testing policy that covers the same concern as Garfield's bundled test policy
+- **WHEN** Garfield selects review tasks
+- **THEN** the repository policy is used for that concern, the bundled policy is marked superseded, and unrelated review tasks are explicitly skipped
+
+### Behavior: Delegate in Bounded Batches
+
+The agent SHALL use one no-edit subagent for each applicable review task or policy, keep at most three Garfield subagents open at once, and drain completed reviewers before starting more.
+
+#### Scenario: Five Applicable Reviews
+
+- **WHEN** five review tasks apply to a code slice
+- **THEN** the agent starts no more than three reviewers, collects and closes completed reviewers, then starts the remaining reviews without relying on hidden queuing
+
+### Behavior: Accept Only Material Findings
+
+The agent SHALL accept a finding only when the current diff introduced or worsened it, made evidence stale, or omitted a required artifact, and when the smallest fix preserves the captured intent.
+
+#### Scenario: Reviewer Suggests an Unrelated Redesign
+
+- **WHEN** a reviewer proposes changing a public API that the requested change did not touch
+- **THEN** the agent defers the suggestion instead of expanding the implementation
+
+### Behavior: Fix and Validate the Slice
+
+The agent SHALL fix accepted blocker and high findings when the smallest change preserves intent, fix qualifying medium findings only when local and current-diff-caused, then run the smallest relevant validation commands.
+
+#### Scenario: Missing Regression Test
+
+- **WHEN** a reviewer finds that the current bug fix omitted a focused regression test
+- **THEN** the agent adds the test, runs the covering test command, and repeats review only for the material edit
+
+### Behavior: Hand Off Concisely
+
+The agent SHALL finish with pass or blocked status, validation results, independent verification when used, and only residual material or deferred concerns.
+
+#### Scenario: Clean Final Pass
+
+- **WHEN** no current-diff blocker, high, or qualifying medium concerns remain and validation passes
+- **THEN** the handoff reports `garfield: pass`, the validation results, and no cycle log or generic advice
+
+## Constraints
+
+### Constraint: No Agentless Substitute
+
+The agent MUST NOT claim Garfield ran when required subagents are unavailable.
+
+### Constraint: No Out-of-Intent Changes
+
+The agent MUST NOT change public behavior, permissions, defaults, validation policy, serialization, or unrelated code unless the user requested it or the current diff caused a regression that requires it.
+
+### Constraint: Preserve User Work
+
+The agent MUST NOT revert unrelated user changes or overwrite work outside the reviewed slice.

--- a/skills/skillet-authoring/SKILL.md
+++ b/skills/skillet-authoring/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: skillet-authoring
-description: Author, improve, or migrate agent skills with the skillet CLI — spec-driven, proven by mechanical evals. Use when asked to create or write an agent skill, improve a skill or its evals, diagnose failing skill evals, or migrate a legacy SKILL.md/spec.yaml skill. Not for merely using an existing skill.
-spec_hash: 1994aadc70ac
+description: Author, improve, or migrate agent skills with the Skillet CLI. Use when asked to create or write an agent skill, improve a skill or its evals, diagnose failing skill evals, or migrate a legacy SKILL.md/spec.yaml skill. Not for merely using an existing skill.
+spec_hash: 9a0baf9a1fcd
 ---
 
 # Skillet Authoring
 
-Skills are built spec-first with the skillet CLI (`skillet`, or `npx @sentry/skillet`): `spec.md` is the contract, `SKILL.md` and `evals/` are derived from it, and eval cases prove each behavior against a real agent. Never write these files from a remembered format.
+Skills are built spec-first with the Skillet CLI (`skillet`, or `npx @sentry/skillet`). `spec.md` defines the behavior, `SKILL.md` contains the agent instructions, and eval cases run the spec scenarios through a real agent CLI. Never write these files from a remembered format.
 
-## The loop
+## Steps
 
 1. Run `skillet status <dir> --json` and do what `next` says. For a brand-new skill, `skillet new <name>` first. Never guess a skill's state or start over when artifacts already exist.
 2. Write `spec.md` before anything derived. If the user's intent, triggers, or edge cases are ambiguous, ask 2–4 pointed questions instead of inventing answers.
 3. For every artifact you write (`spec`, `skill`, `evals`), fetch the format first — `skillet instructions <artifact> <dir> --json` — and follow its template and rules exactly.
 4. Run `skillet validate <dir>` after each artifact and fix every error before moving on. Cover every behavior with at least one eval case; validate warns about uncovered behaviors — clear those warnings before calling the skill complete.
-5. Prove it: `skillet eval <dir> --trials 3 --baseline` measures per-behavior lift, and `--dry` catches cases a do-nothing agent would pass. Add `--report <file>` when the user wants a shareable run artifact (`npx vitest-evals serve <file>` renders it).
+5. Run `skillet eval <dir> --trials 3 --baseline` to compare the tested results with and without the skill. Use `--dry` to find checks that pass before the agent runs. Add `--report <file>` when the user wants a shareable run artifact (`npx vitest-evals serve <file>` renders it).
 
 ## When evals fail
 

--- a/skills/skillet-authoring/SKILL.md
+++ b/skills/skillet-authoring/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: skillet-authoring
-description: Author, improve, or migrate agent skills with the Skillet CLI. Use when asked to create or write an agent skill, improve a skill or its evals, diagnose failing skill evals, or migrate a legacy SKILL.md/spec.yaml skill. Not for merely using an existing skill.
+description: Authors, improves, or migrates agent skills with the Skillet CLI; use when asked to create or write a skill, improve its instructions or evals, diagnose failing evals, or migrate a legacy SKILL.md/spec.yaml skill, but not when merely using an existing skill.
 spec_hash: 9a0baf9a1fcd
 ---
 
 # Skillet Authoring
 
-Skills are built spec-first with the Skillet CLI (`skillet`, or `npx @sentry/skillet`). `spec.md` defines the behavior, `SKILL.md` contains the agent instructions, and eval cases run the spec scenarios through a real agent CLI. Never write these files from a remembered format.
+Use the Skillet CLI (`skillet`, or `npx @sentry/skillet`) to build skills spec-first. Treat `spec.md` as the behavior contract, `SKILL.md` as the agent instructions, and eval cases as repeatable runs of the spec scenarios. Never write these files from a remembered format.
 
 ## Steps
 
@@ -14,7 +14,7 @@ Skills are built spec-first with the Skillet CLI (`skillet`, or `npx @sentry/ski
 2. Write `spec.md` before anything derived. If the user's intent, triggers, or edge cases are ambiguous, ask 2–4 pointed questions instead of inventing answers.
 3. For every artifact you write (`spec`, `skill`, `evals`), fetch the format first — `skillet instructions <artifact> <dir> --json` — and follow its template and rules exactly.
 4. Run `skillet validate <dir>` after each artifact and fix every error before moving on. Cover every behavior with at least one eval case; validate warns about uncovered behaviors — clear those warnings before calling the skill complete.
-5. Run `skillet eval <dir> --trials 3 --baseline` to compare the tested results with and without the skill. Use `--dry` to find checks that pass before the agent runs. Add `--report <file>` when the user wants a shareable run artifact (`npx vitest-evals serve <file>` renders it).
+5. Run `skillet eval <dir> --dry` to find checks that pass before the agent runs. Then run `skillet eval <dir> --trials 3 --baseline` to compare the tested results with and without the skill. Add `--report <file>` when the user wants a shareable run artifact (`npx vitest-evals serve <file>` renders it).
 
 ## When evals fail
 

--- a/skills/skillet-authoring/spec.md
+++ b/skills/skillet-authoring/spec.md
@@ -2,7 +2,7 @@
 
 ## Intent
 
-Drive agent-skill creation, improvement, and migration through the skillet CLI instead of freehand SKILL.md writing. The spec is the contract, SKILL.md is derived from it, and eval cases prove each behavior against a real agent. This skill exists so that "make me a skill" lands on that rail automatically.
+Drive agent-skill creation, improvement, and migration through the Skillet CLI instead of freehand SKILL.md writing. The spec defines the behavior, SKILL.md contains the agent instructions, and eval cases exercise the spec scenarios through a real agent CLI. This skill exists so that "make me a skill" starts with reviewable files and repeatable checks.
 
 ## Triggers
 

--- a/src/instructions/content.test.ts
+++ b/src/instructions/content.test.ts
@@ -9,6 +9,16 @@ describe("eval instructions", () => {
     expect(instructions).toContain("Do not use grep or string presence as a proxy");
     expect(instructions).toContain("any deterministic failure skips the judge");
     expect(instructions).toContain("A judge-only case is valid");
+    expect(instructions).toContain("compare the observed pass rates");
     expect(instructions).not.toContain("grep committed files");
+    expect(instructions).not.toContain("proves nothing");
+    expect(instructions).not.toContain("lift is positive");
+  });
+
+  it("allows authoring meta-content when the skill owns that domain", () => {
+    const instructions = instructionsFor("skill").instructions;
+
+    expect(instructions).toContain("only when the skill's own purpose requires them");
+    expect(instructions).not.toContain("nothing about specs, evals, skillet");
   });
 });

--- a/src/instructions/content.ts
+++ b/src/instructions/content.ts
@@ -41,9 +41,9 @@ Body rules:
 - Express every behavior from the spec; keep the spec's constraints as explicit never-do lines. If a behavior cannot be expressed without contradicting another, stop and fix the spec instead.
 - Structure for execution: lead with the workflow or decision points, not background. Concrete examples beat abstract rules — one good worked example per tricky behavior.
 - Keep SKILL.md under ~150 lines. Detail that only matters mid-task (long tables, API references, edge-case catalogs) goes in references/<topic>.md files, linked with a one-line pointer that says when to open them.
-- No meta-content: nothing about specs, evals, skillet, or how the skill was authored.
+- Keep authoring meta-content out of ordinary skills. Mention specs, evals, or Skillet only when the skill's own purpose requires them.
 
-After writing: 'skillet validate' checks frontmatter; 'skillet eval' is the real test.`;
+After writing: 'skillet validate' checks frontmatter; 'skillet eval' runs the cases.`;
 
 const EVALS_INSTRUCTIONS = `Write eval cases under evals/cases/ — one YAML file per case, at least one case per behavior in spec.md (uncovered behaviors are validation warnings). Name the file after the behavior it tests (e.g. commit-message-format.yaml).
 
@@ -69,7 +69,7 @@ Rules that keep evals honest:
 - The workspace after the run is the whole observable record for deterministic checks; transcripts are only visible to judges. Check artifacts, not phrasing.
 - Skill installation itself adds files to the workspace (.claude/ for claude, AGENTS.md for codex). Never assert repo-wide cleanliness; assert that the specific files you care about are unchanged (e.g. git status --porcelain -- . ':(exclude).claude' ':(exclude)AGENTS.md').
 - Fixtures are committed starting states (a repo, a codebase excerpt); setup is for cheap dynamic state (git init, timestamps). Fixture directories must exist — validation fails on dangling slugs.
-- A case that passes without the skill installed proves nothing: design cases where the unskilled agent plausibly does something else, then confirm with 'skillet eval --baseline' that lift is positive.
+- A passing case may also pass without the skill installed. Design cases where the configured agent could plausibly behave differently, then use 'skillet eval --baseline' to compare the observed pass rates with and without the skill.
 - Set trials > 1 only for behaviors you have seen flake; otherwise keep runs cheap.
 
 After writing: 'skillet validate' (schema + coverage), then 'skillet eval' to run.`;


### PR DESCRIPTION
Tightens Skillet's documentation and authoring guidance after parallel technical-accuracy, Plain Speech, and fresh-reader audits. Eval results are scoped to the tested cases and configuration rather than framed as a general quality signal, the first-skill tutorial is complete and mechanically validated, and the shipped authoring skill now follows the current CLI-served rendering rules.

Adds two full dogfood conversions under `examples/`:

- Garfield preserves the exact Apache-2.0 upstream snapshot from `dcramer/agents`, then provides a Skillet-authored spec, compact skill, copied policy references, review fixture, and six behavior-complete eval cases.
- Effect preserves the exact MIT upstream snapshot from `kitlangton/skills`, then provides a Skillet-authored spec, compact reference-driven skill, an Effect fixture, and eight semantic eval cases without API-token grep piles.

Both upstream snapshots are pinned by commit and include their licenses. All three example skills validate with complete coverage, all 17 YAML files parse, and every dry run confirms that no case passes with a do-nothing agent. The root suite remains green with 98 tests.

The CLI authoring instructions also now allow domain-required authoring meta-content and describe baseline as a comparison of observed results rather than proof or a positive-lift requirement.
