### PR TITLE
docs: Add copyable setup prompt

### DIFF
--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -17,6 +17,26 @@ Ask your coding agent to create or improve a skill. The authoring skill uses the
 
 Skillet does not claim that a passing eval makes a skill universally correct. Evals give you repeatable evidence for the scenarios you define and a way to keep improving the skill.
 
+## Set Up Skillet
+
+Paste this into your coding agent:
+
+```text
+Set up Skillet for me using the official source:
+https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring
+
+1. Install the latest Skillet CLI globally with npm.
+2. Run skillet init --no-prompt to install skillet-authoring in user scope.
+3. Do not modify this repository or install project-local skill files.
+4. Verify skillet --version and confirm skillet-authoring is installed in the user skill directory.
+
+Use these commands:
+npm install -g @sentry/skillet
+skillet init --no-prompt
+
+If a command fails, stop and explain the failure instead of switching packages, scopes, or repositories.
+```
+
 ## Start Here
 
 - [Quickstart](/quickstart.md)

--- a/docs/src/agent/index.md
+++ b/docs/src/agent/index.md
@@ -22,19 +22,7 @@ Skillet does not claim that a passing eval makes a skill universally correct. Ev
 Paste this into your coding agent:
 
 ```text
-Set up Skillet for me using the official source:
-https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring
-
-1. Install the latest Skillet CLI globally with npm.
-2. Run skillet init --no-prompt to install skillet-authoring in user scope.
-3. Do not modify this repository or install project-local skill files.
-4. Verify skillet --version and confirm skillet-authoring is installed in the user skill directory.
-
-Use these commands:
-npm install -g @sentry/skillet
-skillet init --no-prompt
-
-If a command fails, stop and explain the failure instead of switching packages, scopes, or repositories.
+Install the skillet-authoring skill from https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring in user scope for me.
 ```
 
 ## Start Here

--- a/docs/src/components/SetupPrompt.astro
+++ b/docs/src/components/SetupPrompt.astro
@@ -1,17 +1,6 @@
 ---
-const prompt = `Set up Skillet for me using the official source:
-https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring
-
-1. Install the latest Skillet CLI globally with npm.
-2. Run skillet init --no-prompt to install skillet-authoring in user scope.
-3. Do not modify this repository or install project-local skill files.
-4. Verify skillet --version and confirm skillet-authoring is installed in the user skill directory.
-
-Use these commands:
-npm install -g @sentry/skillet
-skillet init --no-prompt
-
-If a command fails, stop and explain the failure instead of switching packages, scopes, or repositories.`;
+const prompt =
+  "Install the skillet-authoring skill from https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring in user scope for me.";
 ---
 
 <section class="skillet-setup-prompt">
@@ -19,10 +8,10 @@ If a command fails, stop and explain the failure instead of switching packages, 
     <p class="skillet-kicker">One-prompt setup</p>
     <h2>Paste this into your agent.</h2>
     <p>
-      It installs the CLI and the
+      The
       <a href="https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring"
         ><code>skillet-authoring</code> skill</a
-      > in user scope, then verifies both.
+      > already knows how to call Skillet when it needs the CLI.
     </p>
   </div>
 

--- a/docs/src/components/SetupPrompt.astro
+++ b/docs/src/components/SetupPrompt.astro
@@ -1,0 +1,62 @@
+---
+const prompt = `Set up Skillet for me using the official source:
+https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring
+
+1. Install the latest Skillet CLI globally with npm.
+2. Run skillet init --no-prompt to install skillet-authoring in user scope.
+3. Do not modify this repository or install project-local skill files.
+4. Verify skillet --version and confirm skillet-authoring is installed in the user skill directory.
+
+Use these commands:
+npm install -g @sentry/skillet
+skillet init --no-prompt
+
+If a command fails, stop and explain the failure instead of switching packages, scopes, or repositories.`;
+---
+
+<section class="skillet-setup-prompt">
+  <div class="skillet-section-heading">
+    <p class="skillet-kicker">One-prompt setup</p>
+    <h2>Paste this into your agent.</h2>
+    <p>
+      It installs the CLI and the
+      <a href="https://github.com/getsentry/skillet/tree/main/skills/skillet-authoring"
+        ><code>skillet-authoring</code> skill</a
+      > in user scope, then verifies both.
+    </p>
+  </div>
+
+  <div class="skillet-prompt-window" data-setup-prompt>
+    <div class="skillet-prompt-header">
+      <span>setup-prompt.txt</span>
+      <button type="button" data-copy-prompt>Copy prompt</button>
+    </div>
+    <pre><code>{prompt}</code></pre>
+  </div>
+</section>
+
+<script>
+  for (const button of document.querySelectorAll("[data-copy-prompt]")) {
+    button.addEventListener("click", async () => {
+      const prompt = button.closest("[data-setup-prompt]")?.querySelector("code")?.textContent;
+      if (!prompt) return;
+
+      try {
+        await navigator.clipboard.writeText(prompt);
+        button.textContent = "Copied";
+      } catch {
+        const code = button.closest("[data-setup-prompt]")?.querySelector("code");
+        if (!code) return;
+
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        button.textContent = "Press ⌘C";
+      }
+
+      setTimeout(() => (button.textContent = "Copy prompt"), 1600);
+    });
+  }
+</script>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -14,6 +14,10 @@ hero:
       icon: external
 ---
 
+import SetupPrompt from "../../components/SetupPrompt.astro";
+
+<SetupPrompt />
+
 <div className="skillet-home">
   <section className="skillet-section skillet-install-section">
     <div>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -77,6 +77,67 @@
   width: 100%;
 }
 
+.skillet-setup-prompt {
+  margin: 1rem auto 3.25rem;
+  max-width: 70rem;
+  width: 100%;
+}
+
+.skillet-prompt-window {
+  background: #111114;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+  overflow: hidden;
+}
+
+.skillet-prompt-header {
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  display: flex;
+  justify-content: space-between;
+  min-height: 2.5rem;
+  padding: 0 0.85rem;
+}
+
+.skillet-prompt-header span {
+  color: rgba(255, 255, 255, 0.58);
+  font-family: var(--__sl-font-mono);
+  font-size: 0.72rem;
+}
+
+.skillet-prompt-header button {
+  background: transparent;
+  border: 0;
+  color: #d8c4ff;
+  cursor: pointer;
+  font-family: var(--__sl-font);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.45rem 0;
+}
+
+.skillet-prompt-header button:hover {
+  color: #fff;
+}
+
+.skillet-prompt-window pre {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  max-height: 24rem;
+  overflow: auto;
+  padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.skillet-prompt-window code {
+  color: rgba(255, 255, 255, 0.8);
+  font-family: var(--__sl-font-mono);
+  font-size: 0.78rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
 html,
 body {
   overflow-x: clip;
@@ -214,7 +275,8 @@ body {
 @media (max-width: 760px) {
   .hero:has(.skillet-mega) .stack,
   .hero:has(.skillet-mega) .copy,
-  .skillet-home {
+  .skillet-home,
+  .skillet-setup-prompt {
     max-width: calc(100vw - 2.5rem);
     width: calc(100vw - 2.5rem);
   }


### PR DESCRIPTION
Adds a copyable one-line setup prompt directly below the landing hero:

> Install the skillet-authoring skill from the official repository path in user scope for me.

The skill already knows how to call `skillet` or `npx @sentry/skillet` when it needs the CLI, so the prompt does not prescribe npm installation commands or verification steps. The same sentence appears in the agent-readable homepage.
